### PR TITLE
Add sturdy headless property that can be queried internally and by mods

### DIFF
--- a/ResoniteModLoader/LoadProgressIndicator.cs
+++ b/ResoniteModLoader/LoadProgressIndicator.cs
@@ -23,11 +23,10 @@ internal static class LoadProgressIndicator {
 		}
 	}
 
-	private static bool isHeadless => Type.GetType("FrooxEngine.Headless.HeadlessCommands, Resonite") != null;
 	// Returned true means success, false means something went wrong.
 	internal static bool SetCustom(string text) {
 		if (ModLoaderConfiguration.Get().HideVisuals) { return true; }
-		if (!isHeadless) {
+		if (!ModLoader.IsHeadless) {
 			if (ShowSubphase != null) {
 				ShowSubphase.SetValue(Engine.Current.InitProgress, text);
 			}

--- a/ResoniteModLoader/ModLoader.cs
+++ b/ResoniteModLoader/ModLoader.cs
@@ -18,19 +18,14 @@ public class ModLoader {
 	/// <summary>
 	/// True if ResoniteModLoader is being loaded by a headless server
 	/// </summary>
-	public static bool IsHeadless // Extremely thorough, but doesn't rely on any specific class to check for headless presence
-    {
-        get
-        {
-            return _isHeadless ??= AppDomain.CurrentDomain.GetAssemblies().Any(a =>
-            {
+	public static bool IsHeadless { // Extremely thorough, but doesn't rely on any specific class to check for headless presence
+        get {
+            return _isHeadless ??= AppDomain.CurrentDomain.GetAssemblies().Any(a => {
                 IEnumerable<Type> types;
-                try
-                {
+                try {
                     types = a.GetTypes();
                 }
-                catch (ReflectionTypeLoadException e)
-                {
+                catch (ReflectionTypeLoadException e) {
                     types = e.Types;
                 }
                 return types.Any(t => t != null && t.Namespace == "FrooxEngine.Headless");

--- a/ResoniteModLoader/ModLoader.cs
+++ b/ResoniteModLoader/ModLoader.cs
@@ -15,6 +15,30 @@ public class ModLoader {
 	private static readonly List<LoadedResoniteMod> LoadedMods = new(); // used for mod enumeration
 	internal static readonly Dictionary<Assembly, ResoniteMod> AssemblyLookupMap = new(); // used for logging
 	private static readonly Dictionary<string, LoadedResoniteMod> ModNameLookupMap = new(); // used for duplicate mod checking
+	/// <summary>
+	/// True if ResoniteModLoader is being loaded by a headless server
+	/// </summary>
+	public static bool IsHeadless
+    {
+        get
+        {
+            return _isHeadless ??= AppDomain.CurrentDomain.GetAssemblies().Any(a => // Overkill, but better safe than sorry. It only happens once anyways.
+            {
+                IEnumerable<Type> types;
+                try
+                {
+                    types = a.GetTypes();
+                }
+                catch (ReflectionTypeLoadException e)
+                {
+                    types = e.Types;
+                }
+                return types.Any(t => t != null && t.Namespace == "FrooxEngine.Headless");
+            });
+        }
+    }
+
+    private static bool? _isHeadless;
 
 	/// <summary>
 	/// Allows reading metadata for all loaded mods

--- a/ResoniteModLoader/ModLoader.cs
+++ b/ResoniteModLoader/ModLoader.cs
@@ -18,11 +18,11 @@ public class ModLoader {
 	/// <summary>
 	/// True if ResoniteModLoader is being loaded by a headless server
 	/// </summary>
-	public static bool IsHeadless
+	public static bool IsHeadless // Extremely thorough, but doesn't rely on any specific class to check for headless presence
     {
         get
         {
-            return _isHeadless ??= AppDomain.CurrentDomain.GetAssemblies().Any(a => // Overkill, but better safe than sorry. It only happens once anyways.
+            return _isHeadless ??= AppDomain.CurrentDomain.GetAssemblies().Any(a =>
             {
                 IEnumerable<Type> types;
                 try


### PR DESCRIPTION
Adds a public property that mods can query to check if they're running on headless so that they don't need to make their own, and removes the dependency on any one headless-specific class. Instead, it checks if any type is under the `FrooxEngine.Headless` namespace, which is far less likely to change in the future.

The initial check for the namespace is quite intensive, but is immediately cached.

This should save people from having to repeatedly implement their own headless checks.