### PR TITLE
Initial ModConfigurationDataFeed implementation

### DIFF
--- a/ResoniteModLoader/AssemblyHider.cs
+++ b/ResoniteModLoader/AssemblyHider.cs
@@ -48,7 +48,7 @@ internal static class AssemblyHider {
 	/// <param name="harmony">Our RML harmony instance</param>
 	/// <param name="initialAssemblies">Assemblies that were loaded when RML first started</param>
 	internal static void PatchResonite(Harmony harmony, HashSet<Assembly> initialAssemblies) {
-		//if (ModLoaderConfiguration.Get().HideModTypes) {
+		if (ModLoaderConfiguration.Get().HideModTypes) {
 			// initialize the static assembly sets that our patches will need later
 			resoniteAssemblies = GetResoniteAssemblies(initialAssemblies);
 			modAssemblies = GetModAssemblies(resoniteAssemblies);
@@ -68,7 +68,7 @@ internal static class AssemblyHider {
 			MethodInfo getAssembliesTarget = AccessTools.DeclaredMethod(typeof(AppDomain), nameof(AppDomain.GetAssemblies), Array.Empty<Type>());
 			MethodInfo getAssembliesPatch = AccessTools.DeclaredMethod(typeof(AssemblyHider), nameof(GetAssembliesPostfix));
 			harmony.Patch(getAssembliesTarget, postfix: new HarmonyMethod(getAssembliesPatch));
-		//}
+		}
 	}
 
 	private static HashSet<Assembly> GetResoniteAssemblies(HashSet<Assembly> initialAssemblies) {
@@ -116,13 +116,13 @@ internal static class AssemblyHider {
 				// this implies someone late-loaded an assembly after RML, and it was later used in-game
 				// this is super weird, and probably shouldn't ever happen... but if it does, I want to know about it.
 				// since this is an edge case users may want to handle in different ways, the HideLateTypes rml config option allows them to choose.
-				//bool hideLate = true;// ModLoaderConfiguration.Get().HideLateTypes;
-				/*if (log) {
+				bool hideLate = ModLoaderConfiguration.Get().HideLateTypes;
+				if (log) {
 					Logger.WarnInternal($"The \"{name}\" {typeOrAssembly} does not appear to part of Resonite or a mod. It is unclear whether it should be hidden or not. Due to the HideLateTypes config option being {hideLate} it will be {(hideLate ? "Hidden" : "Shown")}");
-				}*/
+				}
 				// if forceShowLate == true, then this function will always return `false` for late-loaded types
 				// if forceShowLate == false, then this function will return `true` when hideLate == true
-				return !forceShowLate;
+				return hideLate && !forceShowLate;
 			}
 		}
 	}

--- a/ResoniteModLoader/Attributes/AutoRegisterConfigKeyAttribute.cs
+++ b/ResoniteModLoader/Attributes/AutoRegisterConfigKeyAttribute.cs
@@ -4,4 +4,23 @@ namespace ResoniteModLoader;
 /// deriving from <see cref="ResoniteMod"/> to be automatically included in that mod's configuration.
 /// </summary>
 [AttributeUsage(AttributeTargets.Field)]
-public sealed class AutoRegisterConfigKeyAttribute : Attribute { }
+public sealed class AutoRegisterConfigKeyAttribute : Attribute {
+	public readonly string GroupName;
+
+	// public readonly IReadOnlyList<string> Subpath;
+
+	public AutoRegisterConfigKeyAttribute() { }
+
+	public AutoRegisterConfigKeyAttribute(string groupName) {
+		GroupName = groupName;
+	}
+
+	// public AutoRegisterConfigKeyAttribute(params string[] subpath) {
+	// 	Subpath = subpath;
+	// }
+
+	// public AutoRegisterConfigKeyAttribute(string groupName, params string[] subpath) {
+	// 	GroupName = groupName;
+	// 	Subpath = subpath;
+	// }
+}

--- a/ResoniteModLoader/DashScreenInjector.cs
+++ b/ResoniteModLoader/DashScreenInjector.cs
@@ -1,0 +1,61 @@
+using FrooxEngine;
+using HarmonyLib;
+
+namespace ResoniteModLoader;
+
+internal sealed class DashScreenInjector
+{
+	internal static RadiantDashScreen? InjectedScreen;
+
+	internal static void PatchScreenManager(Harmony harmony)
+	{
+		MethodInfo SetupDefaultMethod = AccessTools.DeclaredMethod(typeof(UserspaceScreensManager), "SetupDefaults");
+		MethodInfo TryInjectScreenMethod = AccessTools.DeclaredMethod(typeof(DashScreenInjector), nameof(TryInjectScreen));
+		harmony.Patch(SetupDefaultMethod, postfix: new HarmonyMethod(TryInjectScreen));
+	}
+
+	internal static async void TryInjectScreen(UserspaceScreensManager __instance)
+	{
+		if (ModLoaderConfiguration.Get().NoDashScreen)
+		{
+			Logger.DebugInternal("Dash screen will not be injected due to configuration file");
+			return;
+		}
+		if (__instance.World != Userspace.UserspaceWorld)
+		{
+			Logger.WarnInternal("Dash screen will not be injected because we're somehow not in userspace (WTF?)"); // it stands for What the Froox :>
+			return;
+		}
+		if (InjectedScreen is not null && !InjectedScreen.IsRemoved)
+		{
+			Logger.WarnInternal("Dash screen will not be injected again because it already exists");
+		}
+
+		RadiantDash dash = __instance.Slot.GetComponentInParents<RadiantDash>();
+		InjectedScreen = dash.AttachScreen("Mods", RadiantUI_Constants.Hero.RED, OfficialAssets.Graphics.Icons.General.BoxClosed); // Replace with RML icon later
+
+		Slot screenSlot = InjectedScreen.Slot;
+		screenSlot.OrderOffset = 128;
+		screenSlot.PersistentSelf = false;
+
+		SingleFeedView view = screenSlot.AttachComponent<SingleFeedView>();
+		ModConfigurationDataFeed feed = screenSlot.AttachComponent<ModConfigurationDataFeed>();
+
+		Slot templates = screenSlot.AddSlot("Template");
+		templates.ActiveSelf = false;
+
+		if (await templates.LoadObjectAsync(__instance.Cloud.Platform.GetSpawnObjectUri("SettingsItemMappers"), skipHolder: true))
+		{
+			DataFeedItemMapper itemMapper = templates.FindChild("ItemsMapper").GetComponent<DataFeedItemMapper>();
+			view.ItemsManager.TemplateMapper.Target = itemMapper;
+			view.ItemsManager.ContainerRoot.Target = InjectedScreen.ScreenRoot;
+		}
+		else
+		{
+			Logger.ErrorInternal("Failed to load SettingsItemMappers for dash screen, aborting.");
+			InjectedScreen.Slot.Destroy();
+		}
+
+		view.Feed.Target = feed;
+	}
+}

--- a/ResoniteModLoader/DashScreenInjector.cs
+++ b/ResoniteModLoader/DashScreenInjector.cs
@@ -9,9 +9,12 @@ internal sealed class DashScreenInjector
 
 	internal static void PatchScreenManager(Harmony harmony)
 	{
-		MethodInfo SetupDefaultMethod = AccessTools.DeclaredMethod(typeof(UserspaceScreensManager), "SetupDefaults");
-		MethodInfo TryInjectScreenMethod = AccessTools.DeclaredMethod(typeof(DashScreenInjector), nameof(TryInjectScreen));
-		harmony.Patch(SetupDefaultMethod, postfix: new HarmonyMethod(TryInjectScreen));
+		MethodInfo setupDefaultMethod = AccessTools.DeclaredMethod(typeof(UserspaceScreensManager), "SetupDefaults");
+		MethodInfo onLoadingMethod = AccessTools.DeclaredMethod(typeof(UserspaceScreensManager), "OnLoading");
+		MethodInfo tryInjectScreenMethod = AccessTools.DeclaredMethod(typeof(DashScreenInjector), nameof(TryInjectScreen));
+		harmony.Patch(setupDefaultMethod, postfix: new HarmonyMethod(tryInjectScreenMethod));
+		harmony.Patch(onLoadingMethod, postfix: new HarmonyMethod(tryInjectScreenMethod));
+		Logger.DebugInternal("UserspaceScreensManager patched");
 	}
 
 	internal static async void TryInjectScreen(UserspaceScreensManager __instance)
@@ -30,6 +33,8 @@ internal sealed class DashScreenInjector
 		{
 			Logger.WarnInternal("Dash screen will not be injected again because it already exists");
 		}
+
+		Logger.DebugInternal("Injecting dash screen");
 
 		RadiantDash dash = __instance.Slot.GetComponentInParents<RadiantDash>();
 		InjectedScreen = dash.AttachScreen("Mods", RadiantUI_Constants.Hero.RED, OfficialAssets.Graphics.Icons.General.BoxClosed); // Replace with RML icon later
@@ -57,5 +62,7 @@ internal sealed class DashScreenInjector
 		}
 
 		view.Feed.Target = feed;
+
+		Logger.DebugInternal("Dash screen should be injected!");
 	}
 }

--- a/ResoniteModLoader/HarmonyWorker.cs
+++ b/ResoniteModLoader/HarmonyWorker.cs
@@ -9,5 +9,6 @@ internal sealed class HarmonyWorker {
 		ModLoader.LoadMods();
 		ModConfiguration.RegisterShutdownHook(harmony);
 		AssemblyHider.PatchResonite(harmony, initialAssemblies);
+		DashScreenInjector.PatchScreenManager(harmony);
 	}
 }

--- a/ResoniteModLoader/Logger.cs
+++ b/ResoniteModLoader/Logger.cs
@@ -8,6 +8,10 @@ internal sealed class Logger {
 	// logged for null objects
 	internal const string NULL_STRING = "null";
 
+	internal enum LogType { DEBUG, INFO, WARN, ERROR }
+
+	internal static readonly List<(ResoniteModBase?, LogType, string, StackTrace)> LogBuffer = new();
+
 	internal static bool IsDebugEnabled() {
 		return ModLoaderConfiguration.Get().Debug;
 	}
@@ -52,21 +56,24 @@ internal sealed class Logger {
 	internal static void ErrorExternal(object message) => LogInternal(LogType.ERROR, message, SourceFromStackTrace(new(1)));
 	internal static void ErrorListExternal(object[] messages) => LogListInternal(LogType.ERROR, messages, SourceFromStackTrace(new(1)));
 
-	private static void LogInternal(string logTypePrefix, object message, string? source = null) {
+	private static void LogInternal(LogType logType, object message, string? source = null) {
 		message ??= NULL_STRING;
+		string logTypePrefix = LogTypeTag(logType);
 		if (source == null) {
 			UniLog.Log($"{logTypePrefix}[ResoniteModLoader] {message}");
-		} else {
+		}
+		else {
 			UniLog.Log($"{logTypePrefix}[ResoniteModLoader/{source}] {message}");
 		}
 	}
 
-	private static void LogListInternal(string logTypePrefix, object[] messages, string? source) {
+	private static void LogListInternal(LogType logType, object[] messages, string? source) {
 		if (messages == null) {
-			LogInternal(logTypePrefix, NULL_STRING, source);
-		} else {
+			LogInternal(logType, NULL_STRING, source);
+		}
+		else {
 			foreach (object element in messages) {
-				LogInternal(logTypePrefix, element.ToString(), source);
+				LogInternal(logType, element.ToString(), source);
 			}
 		}
 	}
@@ -76,10 +83,5 @@ internal sealed class Logger {
 		return Util.ExecutingMod(stackTrace)?.Name;
 	}
 
-	private static class LogType {
-		internal const string DEBUG = "[DEBUG]";
-		internal const string INFO = "[INFO] ";
-		internal const string WARN = "[WARN] ";
-		internal const string ERROR = "[ERROR]";
-	}
+	private static string LogTypeTag(LogType logType) => $"[{Enum.GetName(typeof(LogType), logType)}]";
 }

--- a/ResoniteModLoader/ModConfigurationDataFeed.cs
+++ b/ResoniteModLoader/ModConfigurationDataFeed.cs
@@ -17,64 +17,60 @@ public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed
 	public override bool UserspaceOnly => true;
 
 	public bool SupportsBackgroundQuerying => true;
+#pragma warning restore CS1591
+#pragma warning disable CS8618, CA1051 // FrooxEngine weaver will take care of these
+	/// <summary>
+	/// Show mod configuration keys marked as internal. Default: False.
+	/// </summary>
+	public readonly Sync<bool> IncludeInternalConfigItems;
+
+	/// <summary>
+	/// Enable or disable the use of custom configuration feeds. Default: True.
+	/// </summary>
+	public readonly Sync<bool> UseModDefinedEnumerate;
+#pragma warning restore CS8618, CA1051
+#pragma warning disable CS1591
+	protected override void OnAttach() {
+		base.OnAttach();
+		IncludeInternalConfigItems.Value = false;
+		UseModDefinedEnumerate.Value = true;
+	}
 
 	public async IAsyncEnumerable<DataFeedItem> Enumerate(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, object viewData) {
 		switch (path.Count) {
 			case 0: {
-					DataFeedCategory modLoaderCategory = new DataFeedCategory();
-					modLoaderCategory.InitBase(
-						itemKey: "ResoniteModLoader",
-						label: $"Open ResoniteModLoader category",
-						path: null,
-						groupingParameters: null
-					);
-					yield return modLoaderCategory;
+					yield return FeedBuilder.Category("ResoniteModLoader", "Open ResoniteModLoader category");
 				}
 				yield break;
 
 			case 1: {
 					if (path[0] != "ResoniteModLoader") yield break;
 
-					DataFeedLabel modLoaderVersion = new DataFeedLabel();
-					modLoaderVersion.InitBase(
-						itemKey: "ResoniteModLoder.Version",
-						label: $"ResoniteModLoader version {ModLoader.VERSION}",
-						path: null,
-						groupingParameters: null
-					);
-					yield return modLoaderVersion;
+					yield return FeedBuilder.Label("ResoniteModLoder.Version", $"ResoniteModLoader version {ModLoader.VERSION}");
+					yield return FeedBuilder.StringIndicator("ResoniteModLoder.LoadedModCount", "Loaded mods:", ModLoader.Mods().Count());
 
-					DataFeedIndicator<string> modLoaderLoadedModCount = new DataFeedIndicator<string>(); // Todo: Make DataFeedIndicator<int> template
-					modLoaderLoadedModCount.InitBase(
-						itemKey: "ResoniteModLoder.LoadedModCount",
-						label: "Loaded mods:",
-						path: null,
-						groupingParameters: null
-					);
-					modLoaderLoadedModCount.InitSetupValue((count) => count.Value = ModLoader.Mods().Count().ToString());
-					yield return modLoaderLoadedModCount;
-
+					List<DataFeedItem> groupChildren = Pool.BorrowList<DataFeedItem>();
 					foreach (ResoniteModBase mod in ModLoader.Mods())
-						if (string.IsNullOrEmpty(searchPhrase) || mod.Name.ToLowerInvariant().Contains(searchPhrase.ToLowerInvariant()))
-							yield return GenerateModInfoGroup(mod);
+						if (string.IsNullOrEmpty(searchPhrase) || mod.Name.IndexOf(searchPhrase, StringComparison.InvariantCultureIgnoreCase) >= 0)
+							yield return GenerateModInfoGroup(mod, false, groupChildren);
+					Pool.Return(ref groupChildren);
 				}
 				yield break;
 
 			case 2: {
-					if (path[0] != "ResoniteModLoader") yield break;
-					string key = path[1];
-					ResoniteModBase mod = ModFromKey(key);
-					yield return GenerateModInfoGroup(mod, true);
+					if (path[0] != "ResoniteModLoader" || !TryModFromKey(path[1], out var mod)) yield break;
+
+					List<DataFeedItem> groupChildren = Pool.BorrowList<DataFeedItem>();
+					yield return GenerateModInfoGroup(mod, true, groupChildren);
+					Pool.Return(ref groupChildren);
 					// GenerateModLogFeed
 					// GenerateModExceptionFeed
 				}
 				yield break;
 
 			case 3: {
-					if (path[0] != "ResoniteModLoader") yield break;
-					string key = path[1];
-					ResoniteModBase mod = ModFromKey(key);
-					switch (path[2].ToLowerInvariant()) {
+					if (path[0] != "ResoniteModLoader" || !TryModFromKey(path[1], out var mod)) yield break;
+					switch (path[2].ToLower()) {
 						case "configuration": {
 
 							}
@@ -98,7 +94,10 @@ public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed
 	}
 
 	public LocaleString PathSegmentName(string segment, int depth) {
-		return $"{segment} ({depth})";
+		return depth switch {
+			2 => ModFromKey(segment)?.Name ?? "INVALID",
+			_ => segment
+		};
 	}
 
 	public object RegisterViewData() {
@@ -114,11 +113,38 @@ public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed
 		Logger.DebugInternal($"ModConfigurationDataFeed.UnregisterViewData called, object: {data}\n{Environment.StackTrace}");
 	}
 #pragma warning restore CS1591
-
+	/// <summary>
+	/// Returns a unique key that can be used to reference this mod.
+	/// </summary>
+	/// <param name="mod">The mod to return a key from.</param>
+	/// <returns>A unique key representing the mod.</returns>
+	/// <seealso cref="ModFromKey"/>
+	/// <seealso cref="TryModFromKey"/>
 	public static string KeyFromMod(ResoniteModBase mod) => mod.ModAssembly!.Sha256;
 
+	/// <summary>
+	/// Returns the mod that corresponds to a unique key.
+	/// </summary>
+	/// <param name="key">A unique key from <see cref="KeyFromMod"/>.</param>
+	/// <returns>The mod that corresponds with the unique key, or null if one couldn't be found.</returns>
+	/// <seealso cref="TryModFromKey"/>
 	public static ResoniteModBase? ModFromKey(string key) => ModLoader.Mods().First((mod) => KeyFromMod(mod) == key);
 
+	/// <summary>
+	/// Tries to get the mod that corresponds to a unique key.
+	/// </summary>
+	/// <param name="key">A unique key from <see cref="KeyFromMod"/>.</param>
+	/// <param name="mod">Set if a matching mod is found.</param>
+	/// <returns>True if a matching mod is found, false otherwise.</returns>
+	public static bool TryModFromKey(string key, out ResoniteModBase mod) {
+		mod = ModFromKey(key)!;
+		return mod is not null;
+	}
+
+	/// <summary>
+	/// Spawns the prompt for a user to open a hyperlink.
+	/// </summary>
+	/// <param name="uri">The URI that the user will be prompted to open.</param>
 	[SyncMethod(typeof(Action<Uri>), [])]
 	public static void OpenURI(Uri uri) {
 		Userspace.UserspaceWorld.RunSynchronously(delegate {
@@ -128,100 +154,26 @@ public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed
 		});
 	}
 
-	private static DataFeedGroup GenerateModInfoGroup(ResoniteModBase mod, bool standalone = false) {
-		DataFeedGroup modFeedGroup = new DataFeedGroup();
-		List<DataFeedItem> groupChildren = new List<DataFeedItem>(); // Could this be a pool list instead?
+	private static DataFeedGroup GenerateModInfoGroup(ResoniteModBase mod, bool standalone = false, List<DataFeedItem> groupChildren = null!) {
+		DataFeedGroup modFeedGroup = new();
+		groupChildren = groupChildren ?? new();
+		groupChildren.Clear();
 		string key = KeyFromMod(mod);
 
-		if (standalone) {
-			DataFeedIndicator<string> modNameIndicator = new DataFeedIndicator<string>();
-			modNameIndicator.InitBase(
-				itemKey: key + ".Name",
-				label: "Name",
-				path: null,
-				groupingParameters: null
-			);
-			modNameIndicator.InitSetupValue((str) => str.Value = mod.Name);
-			groupChildren.Add(modNameIndicator);
-		}
-
-		DataFeedIndicator<string> modAuthorIndicator = new DataFeedIndicator<string>();
-		modAuthorIndicator.InitBase(
-			itemKey: key + ".Author",
-			label: "Author",
-			path: null,
-			groupingParameters: null
-		);
-		modAuthorIndicator.InitSetupValue((str) => str.Value = mod.Author);
-		groupChildren.Add(modAuthorIndicator);
-
-		DataFeedIndicator<string> modVersionIndicator = new DataFeedIndicator<string>();
-		modVersionIndicator.InitBase(
-			itemKey: key + ".Version",
-			label: "Version",
-			path: null,
-			groupingParameters: null
-		);
-		modVersionIndicator.InitSetupValue((str) => str.Value = mod.Version);
-		groupChildren.Add(modVersionIndicator);
+		if (standalone) groupChildren.Add(FeedBuilder.Indicator(key + ".Name", "Name", mod.Name));
+		groupChildren.Add(FeedBuilder.Indicator(key + ".Author", "Author", mod.Author));
+		groupChildren.Add(FeedBuilder.Indicator(key + ".Version", "Version", mod.Version));
 
 		if (standalone) {
-			DataFeedIndicator<string> modAssemblyFileIndicator = new DataFeedIndicator<string>();
-			modAssemblyFileIndicator.InitBase(
-				itemKey: key + ".AssemblyFile",
-				label: "Assembly file",
-				path: null,
-				groupingParameters: null
-			);
-			modAssemblyFileIndicator.InitSetupValue((str) => str.Value = Path.GetFileName(mod.ModAssembly!.File));
-			groupChildren.Add(modAssemblyFileIndicator);
-
-			DataFeedIndicator<string> modAssemblyHashIndicator = new DataFeedIndicator<string>();
-			modAssemblyHashIndicator.InitBase(
-				itemKey: key + ".AssemblyHash",
-				label: "Assembly hash",
-				path: null,
-				groupingParameters: null
-			);
-			modAssemblyHashIndicator.InitSetupValue((str) => str.Value = mod.ModAssembly!.Sha256);
-			groupChildren.Add(modAssemblyHashIndicator);
-
+			groupChildren.Add(FeedBuilder.Indicator(key + ".AssemblyFile", "Assembly file", Path.GetFileName(mod.ModAssembly!.File)));
+			groupChildren.Add(FeedBuilder.Indicator(key + ".AssemblyHash", "Assembly hash", mod.ModAssembly!.Sha256));
 			// TODO: Add initialization time recording
 		}
 
-		if (Uri.TryCreate(mod.Link, UriKind.Absolute, out var uri)) {
-			DataFeedValueAction<Uri> modOpenLinkAction = new DataFeedValueAction<Uri>();
-			modOpenLinkAction.InitBase(
-				itemKey: key + ".OpenLinkAction",
-				label: $"Open mod link ({uri.Host})",
-				path: null,
-				groupingParameters: null
-			);
-			modOpenLinkAction.InitAction((action) => action.Target = OpenURI, uri);
-			groupChildren.Add(modOpenLinkAction);
-		}
+		if (Uri.TryCreate(mod.Link, UriKind.Absolute, out var uri)) groupChildren.Add(FeedBuilder.ValueAction<Uri>(key + ".OpenLinkAction", $"Open mod link ({uri.Host})", (action) => action.Target = OpenURI, uri));
+		if (mod.GetConfiguration() is not null) groupChildren.Add(FeedBuilder.Category(key + ".ConfigurationCategory", "Mod configuration", standalone ? ["Configuration"] : [key, "Configuration"]));
 
-		if (mod.ModConfiguration is not null) {
-			DataFeedCategory modConfigurationCategory = new DataFeedCategory();
-			modConfigurationCategory.InitBase(
-				itemKey: key + ".ConfigurationCategory",
-				label: "Mod configuration",
-				path: [key, "Configuration"],
-				groupingParameters: null
-			);
-			modConfigurationCategory.SetOverrideSubpath(standalone ? ["Configuration"] : [key, "Configuration"]);
-			groupChildren.Add(modConfigurationCategory);
-		}
-
-		modFeedGroup.InitBase(
-			itemKey: key + ".Group",
-			label: standalone ? "Mod info" : mod.Name,
-			path: null,
-			groupingParameters: null,
-			subitems: groupChildren
-		);
-
-		return modFeedGroup;
+		return FeedBuilder.Group(key + ".Group", standalone ? "Mod info" : mod.Name, groupChildren);
 	}
 
 	// private static DataFeedGroup GenerateModLogFeed(ResoniteModBase mod, int last = -1) {

--- a/ResoniteModLoader/ModConfigurationDataFeed.cs
+++ b/ResoniteModLoader/ModConfigurationDataFeed.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Elements.Core;

--- a/ResoniteModLoader/ModConfigurationDataFeed.cs
+++ b/ResoniteModLoader/ModConfigurationDataFeed.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Elements.Core;
@@ -7,43 +7,46 @@ using SkyFrost.Base;
 
 namespace ResoniteModLoader;
 
-[GloballyRegistered]
 [Category(new string[] { "Userspace" })]
 public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed, IWorldElement
 {
+	#pragma warning disable CS1591
 	public override bool UserspaceOnly => true;
 
 	public bool SupportsBackgroundQuerying => true;
 
 	public async IAsyncEnumerable<DataFeedItem> Enumerate(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, object viewData) {
+		switch (path.Count)
 		{
-			DataFeedLabel modLoaderVersion = new DataFeedLabel();
-			modLoaderVersion.InitBase("ResoniteModLoder.Version", null, null, $"ResoniteModLoader version {ModLoader.VERSION}");
-			yield return modLoaderVersion;
+			case 0: {
+				DataFeedLabel modLoaderVersion = new DataFeedLabel();
+				modLoaderVersion.InitBase(
+					itemKey: "ResoniteModLoder.Version",
+					label: $"ResoniteModLoader version {ModLoader.VERSION}",
+					path: null,
+					groupingParameters: null
+				);
+				yield return modLoaderVersion;
 
-			DataFeedLabel modLoaderLoadedModCount = new DataFeedLabel();
-			modLoaderLoadedModCount.InitBase("ResoniteModLoder.LoadedModCount", null, null, $"{ModLoader.Mods().Count()} mods loaded");
-			yield return modLoaderLoadedModCount;
+				DataFeedIndicator<int> modLoaderLoadedModCount = new DataFeedIndicator<int>();
+				modLoaderLoadedModCount.InitBase(
+					itemKey: "ResoniteModLoder.LoadedModCount",
+					label: "Loaded mods:",
+					path: null,
+					groupingParameters: null
+				);
+				modLoaderLoadedModCount.InitSetupValue((count) => count.Value = ModLoader.Mods().Count());
+				yield return modLoaderLoadedModCount;
+
+				foreach (ResoniteModBase mod in ModLoader.Mods()) yield return GenerateModFeedGroup(mod);
+			}
+			break;
+			case 2: {
+
+			}
+			break;
 		}
 
-		foreach (ResoniteModBase mod in ModLoader.Mods())
-		{
-			DataFeedGroup modDataFeedGroup = new DataFeedGroup();
-			modDataFeedGroup.InitBase(mod.Name + ".Group", null, null, mod.Name);
-			yield return modDataFeedGroup;
-
-			DataFeedLabel authorDataFeedLabel = new DataFeedLabel();
-			authorDataFeedLabel.InitBase(mod.Name + ".Author", null, null, $"Author: {mod.Author}");
-			yield return authorDataFeedLabel;
-
-			DataFeedLabel versionDataFeedLabel = new DataFeedLabel();
-			versionDataFeedLabel.InitBase(mod.Name + ".Version", null, null, $"Version: {mod.Version}");
-			yield return versionDataFeedLabel;
-
-			DataFeedLabel isLoadedDataFeedLabel = new DataFeedLabel();
-			isLoadedDataFeedLabel.InitBase(mod.Name + ".IsLoaded", null, null, $"IsLoaded: {mod.FinishedLoading}");
-			yield return isLoadedDataFeedLabel;
-		}
 	}
 
 	public void ListenToUpdates(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, DataFeedUpdateHandler handler, object viewData) {
@@ -56,7 +59,7 @@ public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed
 
 	public object RegisterViewData() {
 		Logger.DebugInternal("ModConfigurationDataFeed.RegisterViewData called");
-		return null;
+		return null!;
 	}
 
 	public void UnregisterListener(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, DataFeedUpdateHandler handler) {
@@ -65,5 +68,83 @@ public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed
 
 	public void UnregisterViewData(object data) {
 		Logger.DebugInternal($"ModConfigurationDataFeed.UnregisterViewData called, object: {data}");
+	}
+	#pragma warning restore CS1591
+
+	private static DataFeedGroup GenerateModFeedGroup(ResoniteModBase mod) {
+		DataFeedGroup modFeedGroup = new DataFeedGroup();
+		List<DataFeedItem> groupChildren = new List<DataFeedItem>(); // Could this be a pool list instead?
+		string key = mod.ModAssembly!.Sha256;
+
+		DataFeedIndicator<string> modAuthorIndicator = new DataFeedIndicator<string>();
+		modAuthorIndicator.InitBase(
+			itemKey: key + ".Author",
+			label: "Author",
+			path: null,
+			groupingParameters: null
+		);
+		modAuthorIndicator.InitSetupValue((str) => str.Value = mod.Author);
+		groupChildren.Add(modAuthorIndicator);
+
+		DataFeedIndicator<string> modVersionIndicator = new DataFeedIndicator<string>();
+		modVersionIndicator.InitBase(
+			itemKey: key + ".Version",
+			label: "Version",
+			path: null,
+			groupingParameters: null
+		);
+		modVersionIndicator.InitSetupValue((str) => str.Value = mod.Version);
+		groupChildren.Add(modVersionIndicator);
+
+		DataFeedIndicator<string> modAssemblyIndicator = new DataFeedIndicator<string>();
+		modAssemblyIndicator.InitBase(
+			itemKey: key + ".Assembly",
+			label: "File",
+			path: null,
+			groupingParameters: null
+		);
+		modAssemblyIndicator.InitSetupValue((str) => str.Value = Path.GetFileName(mod.ModAssembly!.File));
+		groupChildren.Add(modAssemblyIndicator);
+
+		if (Uri.TryCreate(mod.Link, UriKind.Absolute, out var uri))
+		{
+			DataFeedAction modOpenLinkAction = new DataFeedAction();
+			modOpenLinkAction.InitBase(
+				itemKey: key + ".OpenLinkAction",
+				label: $"Open mod link ({uri.Host})",
+				path: null,
+				groupingParameters: null
+			);
+			modOpenLinkAction.InitAction(delegate {
+				Userspace.UserspaceWorld.RunSynchronously(delegate {
+					Slot slot = Userspace.UserspaceWorld.AddSlot("Hyperlink");
+					slot.PositionInFrontOfUser(float3.Backward);
+					slot.AttachComponent<HyperlinkOpenDialog>().Setup(uri, "Outgoing hyperlink");
+				});
+			});
+			groupChildren.Add(modOpenLinkAction);
+		}
+
+		if (mod.ModConfiguration is not null)
+		{
+			DataFeedCategory modConfigurationCategory = new DataFeedCategory();
+			modConfigurationCategory.InitBase(
+				itemKey: key + ".ConfigurationCategory",
+				label: "Mod configuration",
+				path: new string[] {key, "Configuration"},
+				groupingParameters: null
+			);
+			groupChildren.Add(modConfigurationCategory);
+		}
+
+		modFeedGroup.InitBase(
+			itemKey: key + ".Group",
+			label: mod.Name,
+			path: null,
+			groupingParameters: null,
+			subitems: groupChildren
+		);
+
+		return modFeedGroup;
 	}
 }

--- a/ResoniteModLoader/ModConfigurationDataFeed.cs
+++ b/ResoniteModLoader/ModConfigurationDataFeed.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using Elements.Core;
 using FrooxEngine;
@@ -7,50 +8,93 @@ using SkyFrost.Base;
 
 namespace ResoniteModLoader;
 
-[Category(new string[] { "Userspace" })]
-public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed, IWorldElement
-{
-	#pragma warning disable CS1591
+/// <summary>
+/// A custom data feed that can be used to show information about loaded mods, and alter their configuration. Path must start with "ResoniteModLoder"
+/// </summary>
+[Category(["Userspace"])]
+public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed, IWorldElement {
+#pragma warning disable CS1591
 	public override bool UserspaceOnly => true;
 
 	public bool SupportsBackgroundQuerying => true;
 
 	public async IAsyncEnumerable<DataFeedItem> Enumerate(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, object viewData) {
-		switch (path.Count)
-		{
+		switch (path.Count) {
 			case 0: {
-				DataFeedLabel modLoaderVersion = new DataFeedLabel();
-				modLoaderVersion.InitBase(
-					itemKey: "ResoniteModLoder.Version",
-					label: $"ResoniteModLoader version {ModLoader.VERSION}",
-					path: null,
-					groupingParameters: null
-				);
-				yield return modLoaderVersion;
+					DataFeedCategory modLoaderCategory = new DataFeedCategory();
+					modLoaderCategory.InitBase(
+						itemKey: "ResoniteModLoader",
+						label: $"Open ResoniteModLoader category",
+						path: null,
+						groupingParameters: null
+					);
+					yield return modLoaderCategory;
+				}
+				yield break;
 
-				DataFeedIndicator<int> modLoaderLoadedModCount = new DataFeedIndicator<int>();
-				modLoaderLoadedModCount.InitBase(
-					itemKey: "ResoniteModLoder.LoadedModCount",
-					label: "Loaded mods:",
-					path: null,
-					groupingParameters: null
-				);
-				modLoaderLoadedModCount.InitSetupValue((count) => count.Value = ModLoader.Mods().Count());
-				yield return modLoaderLoadedModCount;
+			case 1: {
+					if (path[0] != "ResoniteModLoader") yield break;
 
-				foreach (ResoniteModBase mod in ModLoader.Mods()) yield return GenerateModFeedGroup(mod);
-			}
-			break;
+					DataFeedLabel modLoaderVersion = new DataFeedLabel();
+					modLoaderVersion.InitBase(
+						itemKey: "ResoniteModLoder.Version",
+						label: $"ResoniteModLoader version {ModLoader.VERSION}",
+						path: null,
+						groupingParameters: null
+					);
+					yield return modLoaderVersion;
+
+					DataFeedIndicator<string> modLoaderLoadedModCount = new DataFeedIndicator<string>(); // Todo: Make DataFeedIndicator<int> template
+					modLoaderLoadedModCount.InitBase(
+						itemKey: "ResoniteModLoder.LoadedModCount",
+						label: "Loaded mods:",
+						path: null,
+						groupingParameters: null
+					);
+					modLoaderLoadedModCount.InitSetupValue((count) => count.Value = ModLoader.Mods().Count().ToString());
+					yield return modLoaderLoadedModCount;
+
+					foreach (ResoniteModBase mod in ModLoader.Mods())
+						if (string.IsNullOrEmpty(searchPhrase) || mod.Name.ToLowerInvariant().Contains(searchPhrase.ToLowerInvariant()))
+							yield return GenerateModInfoGroup(mod);
+				}
+				yield break;
+
 			case 2: {
+					if (path[0] != "ResoniteModLoader") yield break;
+					string key = path[1];
+					ResoniteModBase mod = ModFromKey(key);
+					yield return GenerateModInfoGroup(mod, true);
+					// GenerateModLogFeed
+					// GenerateModExceptionFeed
+				}
+				yield break;
 
-			}
-			break;
+			case 3: {
+					if (path[0] != "ResoniteModLoader") yield break;
+					string key = path[1];
+					ResoniteModBase mod = ModFromKey(key);
+					switch (path[2].ToLowerInvariant()) {
+						case "configuration": {
+
+							}
+							yield break;
+						case "logs": {
+
+							}
+							yield break;
+						case "exceptions": {
+
+							}
+							yield break;
+					}
+				}
+				yield break;
 		}
-
 	}
 
 	public void ListenToUpdates(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, DataFeedUpdateHandler handler, object viewData) {
-		Logger.DebugInternal($"ModConfigurationDataFeed.ListenToUpdates called, handler: {handler}");
+		Logger.DebugInternal($"ModConfigurationDataFeed.ListenToUpdates called, handler: {handler}\n{Environment.StackTrace}");
 	}
 
 	public LocaleString PathSegmentName(string segment, int depth) {
@@ -58,23 +102,48 @@ public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed
 	}
 
 	public object RegisterViewData() {
-		Logger.DebugInternal("ModConfigurationDataFeed.RegisterViewData called");
+		Logger.DebugInternal($"ModConfigurationDataFeed.RegisterViewData called\n{Environment.StackTrace}");
 		return null!;
 	}
 
 	public void UnregisterListener(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, DataFeedUpdateHandler handler) {
-		Logger.DebugInternal($"ModConfigurationDataFeed.UnregisterListener called, handler: {handler}");
+		Logger.DebugInternal($"ModConfigurationDataFeed.UnregisterListener called, handler: {handler}\n{Environment.StackTrace}");
 	}
 
 	public void UnregisterViewData(object data) {
-		Logger.DebugInternal($"ModConfigurationDataFeed.UnregisterViewData called, object: {data}");
+		Logger.DebugInternal($"ModConfigurationDataFeed.UnregisterViewData called, object: {data}\n{Environment.StackTrace}");
 	}
-	#pragma warning restore CS1591
+#pragma warning restore CS1591
 
-	private static DataFeedGroup GenerateModFeedGroup(ResoniteModBase mod) {
+	public static string KeyFromMod(ResoniteModBase mod) => mod.ModAssembly!.Sha256;
+
+	public static ResoniteModBase? ModFromKey(string key) => ModLoader.Mods().First((mod) => KeyFromMod(mod) == key);
+
+	[SyncMethod(typeof(Action<Uri>), [])]
+	public static void OpenURI(Uri uri) {
+		Userspace.UserspaceWorld.RunSynchronously(delegate {
+			Slot slot = Userspace.UserspaceWorld.AddSlot("Hyperlink");
+			slot.PositionInFrontOfUser(float3.Backward);
+			slot.AttachComponent<HyperlinkOpenDialog>().Setup(uri, "Outgoing hyperlink");
+		});
+	}
+
+	private static DataFeedGroup GenerateModInfoGroup(ResoniteModBase mod, bool standalone = false) {
 		DataFeedGroup modFeedGroup = new DataFeedGroup();
 		List<DataFeedItem> groupChildren = new List<DataFeedItem>(); // Could this be a pool list instead?
-		string key = mod.ModAssembly!.Sha256;
+		string key = KeyFromMod(mod);
+
+		if (standalone) {
+			DataFeedIndicator<string> modNameIndicator = new DataFeedIndicator<string>();
+			modNameIndicator.InitBase(
+				itemKey: key + ".Name",
+				label: "Name",
+				path: null,
+				groupingParameters: null
+			);
+			modNameIndicator.InitSetupValue((str) => str.Value = mod.Name);
+			groupChildren.Add(modNameIndicator);
+		}
 
 		DataFeedIndicator<string> modAuthorIndicator = new DataFeedIndicator<string>();
 		modAuthorIndicator.InitBase(
@@ -96,50 +165,57 @@ public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed
 		modVersionIndicator.InitSetupValue((str) => str.Value = mod.Version);
 		groupChildren.Add(modVersionIndicator);
 
-		DataFeedIndicator<string> modAssemblyIndicator = new DataFeedIndicator<string>();
-		modAssemblyIndicator.InitBase(
-			itemKey: key + ".Assembly",
-			label: "File",
-			path: null,
-			groupingParameters: null
-		);
-		modAssemblyIndicator.InitSetupValue((str) => str.Value = Path.GetFileName(mod.ModAssembly!.File));
-		groupChildren.Add(modAssemblyIndicator);
+		if (standalone) {
+			DataFeedIndicator<string> modAssemblyFileIndicator = new DataFeedIndicator<string>();
+			modAssemblyFileIndicator.InitBase(
+				itemKey: key + ".AssemblyFile",
+				label: "Assembly file",
+				path: null,
+				groupingParameters: null
+			);
+			modAssemblyFileIndicator.InitSetupValue((str) => str.Value = Path.GetFileName(mod.ModAssembly!.File));
+			groupChildren.Add(modAssemblyFileIndicator);
 
-		if (Uri.TryCreate(mod.Link, UriKind.Absolute, out var uri))
-		{
-			DataFeedAction modOpenLinkAction = new DataFeedAction();
+			DataFeedIndicator<string> modAssemblyHashIndicator = new DataFeedIndicator<string>();
+			modAssemblyHashIndicator.InitBase(
+				itemKey: key + ".AssemblyHash",
+				label: "Assembly hash",
+				path: null,
+				groupingParameters: null
+			);
+			modAssemblyHashIndicator.InitSetupValue((str) => str.Value = mod.ModAssembly!.Sha256);
+			groupChildren.Add(modAssemblyHashIndicator);
+
+			// TODO: Add initialization time recording
+		}
+
+		if (Uri.TryCreate(mod.Link, UriKind.Absolute, out var uri)) {
+			DataFeedValueAction<Uri> modOpenLinkAction = new DataFeedValueAction<Uri>();
 			modOpenLinkAction.InitBase(
 				itemKey: key + ".OpenLinkAction",
 				label: $"Open mod link ({uri.Host})",
 				path: null,
 				groupingParameters: null
 			);
-			modOpenLinkAction.InitAction(delegate {
-				Userspace.UserspaceWorld.RunSynchronously(delegate {
-					Slot slot = Userspace.UserspaceWorld.AddSlot("Hyperlink");
-					slot.PositionInFrontOfUser(float3.Backward);
-					slot.AttachComponent<HyperlinkOpenDialog>().Setup(uri, "Outgoing hyperlink");
-				});
-			});
+			modOpenLinkAction.InitAction((action) => action.Target = OpenURI, uri);
 			groupChildren.Add(modOpenLinkAction);
 		}
 
-		if (mod.ModConfiguration is not null)
-		{
+		if (mod.ModConfiguration is not null) {
 			DataFeedCategory modConfigurationCategory = new DataFeedCategory();
 			modConfigurationCategory.InitBase(
 				itemKey: key + ".ConfigurationCategory",
 				label: "Mod configuration",
-				path: new string[] {key, "Configuration"},
+				path: [key, "Configuration"],
 				groupingParameters: null
 			);
+			modConfigurationCategory.SetOverrideSubpath(standalone ? ["Configuration"] : [key, "Configuration"]);
 			groupChildren.Add(modConfigurationCategory);
 		}
 
 		modFeedGroup.InitBase(
 			itemKey: key + ".Group",
-			label: mod.Name,
+			label: standalone ? "Mod info" : mod.Name,
 			path: null,
 			groupingParameters: null,
 			subitems: groupChildren
@@ -147,4 +223,12 @@ public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed
 
 		return modFeedGroup;
 	}
+
+	// private static DataFeedGroup GenerateModLogFeed(ResoniteModBase mod, int last = -1) {
+
+	// }
+
+	// private static DataFeedGroup GenerateModExceptionFeed(ResoniteModBase mod, int last = -1) {
+
+	// }
 }

--- a/ResoniteModLoader/ModConfigurationDataFeed.cs
+++ b/ResoniteModLoader/ModConfigurationDataFeed.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Elements.Core;
+using FrooxEngine;
+using SkyFrost.Base;
+
+namespace ResoniteModLoader;
+
+[GloballyRegistered]
+[Category(new string[] { "Userspace" })]
+public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed, IWorldElement
+{
+	public override bool UserspaceOnly => true;
+
+	public bool SupportsBackgroundQuerying => true;
+
+	public async IAsyncEnumerable<DataFeedItem> Enumerate(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, object viewData) {
+		{
+			DataFeedLabel modLoaderVersion = new DataFeedLabel();
+			modLoaderVersion.InitBase("ResoniteModLoder.Version", null, null, $"ResoniteModLoader version {ModLoader.VERSION}");
+			yield return modLoaderVersion;
+
+			DataFeedLabel modLoaderLoadedModCount = new DataFeedLabel();
+			modLoaderLoadedModCount.InitBase("ResoniteModLoder.LoadedModCount", null, null, $"{ModLoader.Mods().Count()} mods loaded");
+			yield return modLoaderLoadedModCount;
+		}
+
+		foreach (ResoniteModBase mod in ModLoader.Mods())
+		{
+			DataFeedGroup modDataFeedGroup = new DataFeedGroup();
+			modDataFeedGroup.InitBase(mod.Name + ".Group", null, null, mod.Name);
+			yield return modDataFeedGroup;
+
+			DataFeedLabel authorDataFeedLabel = new DataFeedLabel();
+			authorDataFeedLabel.InitBase(mod.Name + ".Author", null, null, $"Author: {mod.Author}");
+			yield return authorDataFeedLabel;
+
+			DataFeedLabel versionDataFeedLabel = new DataFeedLabel();
+			versionDataFeedLabel.InitBase(mod.Name + ".Version", null, null, $"Version: {mod.Version}");
+			yield return versionDataFeedLabel;
+
+			DataFeedLabel isLoadedDataFeedLabel = new DataFeedLabel();
+			isLoadedDataFeedLabel.InitBase(mod.Name + ".IsLoaded", null, null, $"IsLoaded: {mod.FinishedLoading}");
+			yield return isLoadedDataFeedLabel;
+		}
+	}
+
+	public void ListenToUpdates(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, DataFeedUpdateHandler handler, object viewData) {
+		Logger.DebugInternal($"ModConfigurationDataFeed.ListenToUpdates called, handler: {handler}");
+	}
+
+	public LocaleString PathSegmentName(string segment, int depth) {
+		return $"{segment} ({depth})";
+	}
+
+	public object RegisterViewData() {
+		Logger.DebugInternal("ModConfigurationDataFeed.RegisterViewData called");
+		return null;
+	}
+
+	public void UnregisterListener(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, DataFeedUpdateHandler handler) {
+		Logger.DebugInternal($"ModConfigurationDataFeed.UnregisterListener called, handler: {handler}");
+	}
+
+	public void UnregisterViewData(object data) {
+		Logger.DebugInternal($"ModConfigurationDataFeed.UnregisterViewData called, object: {data}");
+	}
+}

--- a/ResoniteModLoader/ModConfigurationDataFeed.cs
+++ b/ResoniteModLoader/ModConfigurationDataFeed.cs
@@ -38,8 +38,8 @@ public class ModConfigurationDataFeed : Component, IDataFeedComponent, IDataFeed
 					yield return FeedBuilder.Category(KeyFromMod(mod), mod.Name);
 				yield break;
 			}
-
-			path = path.Prepend("ResoniteModLoader").ToList().AsReadOnly();
+			else if (path[0] != "ResoniteModLoader")
+				path = path.Prepend("ResoniteModLoader").ToList().AsReadOnly();
 		}
 
 		switch (path.Count) {

--- a/ResoniteModLoader/ModConfigurationFeedBuilder.cs
+++ b/ResoniteModLoader/ModConfigurationFeedBuilder.cs
@@ -1,0 +1,74 @@
+using Elements.Core;
+using FrooxEngine;
+using HarmonyLib;
+using System.Collections;
+
+namespace ResoniteModLoader;
+
+public class ModConfigurationFeedBuilder {
+
+	private readonly ModConfiguration Config;
+
+	private readonly Dictionary<ModConfigurationKey, FieldInfo> KeyFields = new();
+
+	public readonly static Dictionary<ModConfiguration, ModConfigurationFeedBuilder> CachedBuilders = new();
+
+	private static bool HasAutoRegisterAttribute(FieldInfo field) => field.GetCustomAttribute<AutoRegisterConfigKeyAttribute>() is not null;
+
+	private static bool HasRangeAttribute(FieldInfo field, out RangeAttribute attribute) {
+		attribute = field.GetCustomAttribute<RangeAttribute>();
+		return attribute is not null;
+	}
+
+	private void AssertChildKey(ModConfigurationKey key) {
+		if (!Config.IsKeyDefined(key))
+			throw new InvalidOperationException($"Mod key ({key}) is not owned by {Config.Owner.Name}'s config");
+	}
+
+	public ModConfigurationFeedBuilder(ModConfiguration config) {
+		Config = config;
+		IEnumerable<FieldInfo> autoConfigKeys = config.Owner.GetType().GetDeclaredFields().Where(HasAutoRegisterAttribute);
+		foreach (FieldInfo field in autoConfigKeys) {
+			ModConfigurationKey key = (ModConfigurationKey)field.GetValue(field.IsStatic ? null : config.Owner);
+			KeyFields[key] = field;
+		}
+		CachedBuilders[config] = this;
+	}
+
+	public IEnumerable<DataFeedItem> RootPage(string searchPhrase = "", bool includeInternal = false) {
+		foreach (ModConfigurationKey key in Config.ConfigurationItemDefinitions) {
+			if (key.InternalAccessOnly && !includeInternal) continue;
+			if (!string.IsNullOrEmpty(searchPhrase) && string.Join("\n", key.Name, key.Description).IndexOf(searchPhrase, StringComparison.InvariantCultureIgnoreCase) < 0) continue;
+			yield return GenerateDataFeedItem(key);
+		}
+	}
+
+	public IEnumerable<DataFeedOrderedItem<int>> OrderedPage(ModConfigurationKey key) {
+		AssertChildKey(key);
+		if (!typeof(IEnumerable).IsAssignableFrom(key.ValueType())) yield break;
+		var value = (IEnumerable)Config.GetValue(key);
+		int i = 0;
+		foreach (object item in value)
+			yield return FeedBuilder.OrderedItem<int>(key.Name + i, key.Name, item.ToString(), i++);
+	}
+
+	public DataFeedValueField<T> GenerateDataFeedField<T>(ModConfigurationKey key) {
+		AssertChildKey(key);
+		return FeedBuilder.ValueField<T>(key.Name, key.Name, key.Description, (field) => field.SyncWithModConfiguration(Config, key));
+	}
+
+	public DataFeedItem GenerateDataFeedItem(ModConfigurationKey key) {
+		AssertChildKey(key);
+		Type valueType = key.ValueType();
+		if (valueType == typeof(dummy))
+			return FeedBuilder.Label(key.Name, key.Description ?? key.Name);
+		else if (valueType == typeof(bool))
+			return FeedBuilder.Toggle(key.Name, key.Name, key.Description, (field) => field.SyncWithModConfiguration(Config, key));
+		else if (valueType == typeof(float) && HasRangeAttribute(KeyFields[key], out RangeAttribute range))
+			return FeedBuilder.Slider<float>(key.Name, key.Name, key.Description, (field) => field.SyncWithModConfiguration(Config, key), range.Min, range.Max, range.TextFormat);
+		else if (valueType != typeof(string) && valueType != typeof(Uri) && typeof(IEnumerable).IsAssignableFrom(valueType))
+			return FeedBuilder.Category(key.Name, key.Name, key.Description);
+		else
+			return (DataFeedItem)typeof(ModConfigurationFeedBuilder).GetMethod(nameof(GenerateDataFeedField)).MakeGenericMethod(key.ValueType()).Invoke(this, [key]);
+	}
+}

--- a/ResoniteModLoader/ModConfigurationValueSync.cs
+++ b/ResoniteModLoader/ModConfigurationValueSync.cs
@@ -1,0 +1,44 @@
+using Elements.Core;
+using FrooxEngine;
+
+namespace ResoniteModLoader;
+
+[Category(["ResoniteModLoder"])]
+public class ModConfigurationValueSync<T> : Component {
+#pragma warning disable CS1591
+	public override bool UserspaceOnly => true;
+#pragma warning restore CS1591
+#pragma warning disable CS8618, CA1051
+	public readonly Sync<string> DefiningModAssembly;
+
+	public readonly Sync<string> ConfigurationKeyName;
+
+	public readonly Sync<bool> DefinitionFound;
+
+	public readonly FieldDrive<T> TargetField;
+#pragma warning restore CS8618, CA1051
+	private ResoniteModBase _mappedMod;
+
+	private ModConfiguration _mappedConfig;
+
+	private ModConfigurationKey _mappedKey;
+
+	public void LoadConfigKey(ModConfiguration config, ModConfigurationKey key) {
+
+		_mappedMod = config.Owner;
+		_mappedConfig = config;
+		_mappedKey = key;
+		DefiningModAssembly.Value = Path.GetFileNameWithoutExtension(config.Owner.ModAssembly!.File);
+		ConfigurationKeyName.Value = key.Name;
+	}
+}
+
+public static class ModConfigurationValueSyncExtensions {
+	public static ModConfigurationValueSync<T> SyncWithModConfiguration<T>(this IField<T> field, ModConfiguration config, ModConfigurationKey key) {
+		ModConfigurationValueSync<T> driver = field.FindNearestParent<Slot>().AttachComponent<ModConfigurationValueSync<T>>();
+		driver.LoadConfigKey(config, key);
+		driver.TargetField.Target = field;
+
+		return driver;
+	}
+}

--- a/ResoniteModLoader/ModLoaderConfiguration.cs
+++ b/ResoniteModLoader/ModLoaderConfiguration.cs
@@ -20,6 +20,7 @@ internal sealed class ModLoaderConfiguration {
 				{ "logconflicts", (value) => _configuration.LogConflicts = bool.Parse(value) },
 				//{ "hidemodtypes", (value) => _configuration.HideModTypes = bool.Parse(value) },
 				//{ "hidelatetypes", (value) => _configuration.HideLateTypes = bool.Parse(value) }
+				{ "nodashscreen", (value) => _configuration.NoDashScreen = bool.Parse(value) },
 			};
 
 			// .NET's ConfigurationManager is some hot trash to the point where I'm just done with it.
@@ -70,5 +71,6 @@ internal sealed class ModLoaderConfiguration {
 	public bool LogConflicts { get; private set; } = true;
 	//public bool HideModTypes { get; private set; } = true;
 	//public bool HideLateTypes { get; private set; } = true;
+	public bool NoDashScreen { get; private set; } = false;
 #pragma warning restore CA1805
 }

--- a/ResoniteModLoader/ModLoaderConfiguration.cs
+++ b/ResoniteModLoader/ModLoaderConfiguration.cs
@@ -12,14 +12,14 @@ internal sealed class ModLoaderConfiguration {
 			_configuration = new ModLoaderConfiguration();
 
 			Dictionary<string, Action<string>> keyActions = new() {
-				//{ "unsafe", (value) => _configuration.Unsafe = bool.Parse(value) },
+				{ "unsafe", (value) => _configuration.Unsafe = bool.Parse(value) },
 				{ "debug", (value) => _configuration.Debug = bool.Parse(value) },
 				{ "hidevisuals", (value) => _configuration.HideVisuals = bool.Parse(value) },
 				{ "nomods", (value) => _configuration.NoMods = bool.Parse(value) },
 				{ "advertiseversion", (value) => _configuration.AdvertiseVersion = bool.Parse(value) },
 				{ "logconflicts", (value) => _configuration.LogConflicts = bool.Parse(value) },
-				//{ "hidemodtypes", (value) => _configuration.HideModTypes = bool.Parse(value) },
-				//{ "hidelatetypes", (value) => _configuration.HideLateTypes = bool.Parse(value) }
+				{ "hidemodtypes", (value) => _configuration.HideModTypes = bool.Parse(value) },
+				{ "hidelatetypes", (value) => _configuration.HideLateTypes = bool.Parse(value) },
 				{ "nodashscreen", (value) => _configuration.NoDashScreen = bool.Parse(value) },
 			};
 
@@ -63,14 +63,14 @@ internal sealed class ModLoaderConfiguration {
 	}
 
 #pragma warning disable CA1805
-	//public bool Unsafe { get; private set; } = false;
+	public bool Unsafe { get; private set; } = false;
 	public bool Debug { get; private set; } = false;
 	public bool NoMods { get; private set; } = false;
 	public bool HideVisuals { get; private set; } = false;
 	public bool AdvertiseVersion { get; private set; } = false;
 	public bool LogConflicts { get; private set; } = true;
-	//public bool HideModTypes { get; private set; } = true;
-	//public bool HideLateTypes { get; private set; } = true;
+	public bool HideModTypes { get; private set; } = true;
+	public bool HideLateTypes { get; private set; } = true;
 	public bool NoDashScreen { get; private set; } = false;
 #pragma warning restore CA1805
 }

--- a/ResoniteModLoader/Properties/AssemblyInfo.cs
+++ b/ResoniteModLoader/Properties/AssemblyInfo.cs
@@ -18,4 +18,4 @@ using Elements.Core;
 [module: Description("FROOXENGINE_WEAVED")]
 
 //Mark as DataModelAssembly for the Plugin loading system to load this assembly
-[assembly: DataModelAssembly(DataModelAssemblyType.Optional)]
+[assembly: DataModelAssembly(DataModelAssemblyType.UserspaceCore)]

--- a/ResoniteModLoader/Properties/AssemblyInfo.cs
+++ b/ResoniteModLoader/Properties/AssemblyInfo.cs
@@ -15,7 +15,7 @@ using Elements.Core;
 
 // Prevent FrooxEngine.Weaver from modifying this assembly, as it doesn't need anything done to it
 // This keeps Weaver from overwriting AssemblyVersionAttribute
-[module: Description("FROOXENGINE_WEAVED")]
+// [module: Description("FROOXENGINE_WEAVED")]
 
 //Mark as DataModelAssembly for the Plugin loading system to load this assembly
 [assembly: DataModelAssembly(DataModelAssemblyType.UserspaceCore)]

--- a/ResoniteModLoader/ResoniteMod.cs
+++ b/ResoniteModLoader/ResoniteMod.cs
@@ -1,3 +1,5 @@
+using FrooxEngine;
+
 namespace ResoniteModLoader;
 
 /// <summary>
@@ -98,5 +100,11 @@ public abstract class ResoniteMod : ResoniteModBase {
 	/// <returns></returns>
 	public virtual IncompatibleConfigurationHandlingOption HandleIncompatibleConfigurationVersions(Version serializedVersion, Version definedVersion) {
 		return IncompatibleConfigurationHandlingOption.ERROR;
+	}
+
+	/// <inheritdoc/>
+	public override async IAsyncEnumerable<DataFeedItem> BuildConfigurationFeed(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, object viewData, bool includeInternal = false) {
+		foreach (DataFeedItem item in this.GenerateModConfigurationFeed(path, groupKeys, searchPhrase, viewData, includeInternal))
+			yield return item;
 	}
 }

--- a/ResoniteModLoader/ResoniteModBase.cs
+++ b/ResoniteModLoader/ResoniteModBase.cs
@@ -1,3 +1,5 @@
+using FrooxEngine;
+
 namespace ResoniteModLoader;
 
 /// <summary>
@@ -45,6 +47,22 @@ public abstract class ResoniteModBase {
 		}
 		return ModConfiguration;
 	}
+
+	public bool TryGetConfiguration(out ModConfiguration configuration) {
+		configuration = ModConfiguration!;
+		return configuration is not null;
+	}
+
+	/// <summary>
+	/// Define a custom configuration DataFeed for this mod.
+	/// </summary>
+	/// <param name="path">Starts empty at the root of the configuration category, allows sub-categories to be used.</param>
+	/// <param name="groupKeys">Passed-through from <see cref="ModConfigurationDataFeed"/>'s Enumerate call.</param>
+	/// <param name="searchPhrase">A phrase by which configuration items should be filtered. Passed-through from <see cref="ModConfigurationDataFeed"/>'s Enumerate call</param>
+	/// <param name="viewData">Passed-through from <see cref="ModConfigurationDataFeed"/>'s Enumerate call.</param>
+	/// <param name="includeInternal">Indicates whether the user has requested that internal configuration keys are included in the returned feed.</param>
+	/// <returns>DataFeedItem's to be directly returned by the calling <see cref="ModConfigurationDataFeed"/>.</returns>
+	public abstract IAsyncEnumerable<DataFeedItem> BuildConfigurationFeed(IReadOnlyList<string> path, IReadOnlyList<string> groupKeys, string searchPhrase, object viewData, bool includeInternal = false);
 
 	internal bool FinishedLoading { get; set; }
 }

--- a/ResoniteModLoader/ResoniteModLoader.csproj
+++ b/ResoniteModLoader/ResoniteModLoader.csproj
@@ -31,6 +31,10 @@
 			<HintPath>$(ResonitePath)Resonite_Data\Managed\Elements.Core.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="Elements.Quantity">
+			<HintPath>$(ResonitePath)Resonite_Data\Managed\Elements.Quantity.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
 		<Reference Include="FrooxEngine">
 			<HintPath>$(ResonitePath)Resonite_Data\Managed\FrooxEngine.dll</HintPath>
 			<Private>False</Private>

--- a/ResoniteModLoader/ResoniteModLoader.csproj
+++ b/ResoniteModLoader/ResoniteModLoader.csproj
@@ -5,7 +5,7 @@
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<TargetFramework>net472</TargetFramework>
 		<FileAlignment>512</FileAlignment>
-		<LangVersion>10.0</LangVersion>
+		<LangVersion>12</LangVersion>
 		<Nullable>enable</Nullable>
 		<Deterministic>true</Deterministic>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>

--- a/ResoniteModLoader/ResoniteModLoader.csproj
+++ b/ResoniteModLoader/ResoniteModLoader.csproj
@@ -26,6 +26,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Lib.Harmony" Version="2.3.3" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 		<Reference Include="Elements.Core">
 			<HintPath>$(ResonitePath)Resonite_Data\Managed\Elements.Core.dll</HintPath>
 			<Private>False</Private>
@@ -53,9 +54,6 @@
 		<Reference Include="UnityEngine.CoreModule">
 			<HintPath>$(ResonitePath)Resonite_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
 			<Private>False</Private>
-		</Reference>
-		<Reference Include="Microsoft.Bcl.AsyncInterfaces">
-			<HintPath>$(ResonitePath)Resonite_Data\Managed\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 

--- a/ResoniteModLoader/ResoniteModLoader.csproj
+++ b/ResoniteModLoader/ResoniteModLoader.csproj
@@ -34,6 +34,14 @@
 			<HintPath>$(ResonitePath)Resonite_Data\Managed\FrooxEngine.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<Reference Include="SkyFrost.Base">
+			<HintPath>$(ResonitePath)Resonite_Data\Managed\SkyFrost.Base.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<Reference Include="SkyFrost.Base.Models">
+			<HintPath>$(ResonitePath)Resonite_Data\Managed\SkyFrost.Base.Models.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
 		<Reference Include="Newtonsoft.Json">
 			<HintPath>$(ResonitePath)Resonite_Data\Managed\Newtonsoft.Json.dll</HintPath>
 			<Private>False</Private>
@@ -43,8 +51,11 @@
 			<Private>False</Private>
 		</Reference>
 		<Reference Include="UnityEngine.CoreModule">
-			<HintPath>R:\SteamLibrary\steamapps\common\Resonite\Resonite_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+			<HintPath>$(ResonitePath)Resonite_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
 			<Private>False</Private>
+		</Reference>
+		<Reference Include="Microsoft.Bcl.AsyncInterfaces">
+			<HintPath>$(ResonitePath)Resonite_Data\Managed\Microsoft.Bcl.AsyncInterfaces.dll</HintPath>
 		</Reference>
 	</ItemGroup>
 

--- a/ResoniteModLoader/Utility/FeedBuilder.cs
+++ b/ResoniteModLoader/Utility/FeedBuilder.cs
@@ -1,10 +1,15 @@
 using Elements.Core;
 using Elements.Quantity;
 using FrooxEngine;
+using HarmonyLib;
 
 namespace ResoniteModLoader;
 
+/// <summary>
+/// Utility class to easily generate DataFeedItem's.
+/// </summary>
 public static class FeedBuilder {
+#pragma warning disable CS8625, CS1591, CA1715
 	public static T Item<T>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where T : DataFeedItem
 		=> Activator.CreateInstance<T>().ChainInitBase(itemKey, path, groupingParameters, label, icon, setupVisible, setupEnabled, subitems, customEntity);
 
@@ -200,11 +205,11 @@ public static class FeedBuilder {
 	public static T Item<T>(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where T : DataFeedItem
 		=> Activator.CreateInstance<T>().ChainInitBase(itemKey, path, groupingParameters, label, description, icon, setupVisible, setupEnabled, subitems, customEntity);
 
-	// CONFLICT AB
+	// CONFLICT CD
 	public static DataFeedCategory Category(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
 		=> Item<DataFeedCategory>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
 
-	// CONFLICT BA
+	// CONFLICT DC
 	public static DataFeedCategory Category(string itemKey, LocaleString label, LocaleString description, string[] subpath, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
 		=> Category(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainSetOverrideSubpath(subpath);
 
@@ -257,10 +262,10 @@ public static class FeedBuilder {
 		=> Item<DataFeedLabel>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
 
 	public static DataFeedLabel Label(string itemKey, LocaleString label, LocaleString description, colorX color, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
-		=> Label(itemKey, $"<color={color.ToHexString(true)}>{label}</color>", path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+		=> Label(itemKey, $"<color={color.ToHexString(true)}>{label}</color>", description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
 
 	public static DataFeedLabel Label(string itemKey, LocaleString label, LocaleString description, color color, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
-		=> Label(itemKey, $"<color={color.ToHexString(true)}>{label}</color>", path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+		=> Label(itemKey, $"<color={color.ToHexString(true)}>{label}</color>", description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
 
 	public static DataFeedIndicator<T> Indicator<T>(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
 		=> Item<DataFeedIndicator<T>>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
@@ -386,120 +391,165 @@ public static class FeedBuilder {
 
 	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, T min, T max, string formatting, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
 		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue).ChainInitFormatting<DataFeedSlider<T>, T>(formatting);
+#pragma warning restore CS8625, CS1591, CA1715
 }
 
+/// <summary>
+/// Extends all DataFeedItem's "Init" methods so they can be called in a chain (methods return original item).
+/// </summary>
 public static class DataFeedItemChaining {
+#pragma warning disable CS8625, CA1715
+	/// <summary>Mapped to InitBase</summary>
 	public static I ChainInitBase<I>(this I item, string itemKey, IReadOnlyList<string> path, IReadOnlyList<string> groupingParameters, LocaleString label, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where I : DataFeedItem {
 		item.InitBase(itemKey, path, groupingParameters, label, icon, setupVisible, setupEnabled, subitems, customEntity);
 		return item;
 	}
 
+	/// <summary>Mapped to InitBase</summary>
 	public static I ChainInitBase<I>(this I item, string itemKey, IReadOnlyList<string> path, IReadOnlyList<string> groupingParameters, LocaleString label, LocaleString description, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where I : DataFeedItem {
 		item.InitBase(itemKey, path, groupingParameters, label, description, icon, setupVisible, setupEnabled, subitems, customEntity);
 		return item;
 	}
 
+	/// <summary>Mapped to InitVisible</summary>
 	public static I ChainInitVisible<I>(this I item, Action<IField<bool>> setupVisible) where I : DataFeedItem {
 		item.InitVisible(setupVisible);
 		return item;
 	}
 
+	/// <summary>Mapped to InitEnabled</summary>
 	public static I ChainInitEnabled<I>(this I item, Action<IField<bool>> setupEnabled) where I : DataFeedItem {
 		item.InitEnabled(setupEnabled);
 		return item;
 	}
 
+	/// <summary>Mapped to InitDescription</summary>
 	public static I ChainInitDescription<I>(this I item, LocaleString description) where I : DataFeedItem {
 		item.InitDescription(description);
 		return item;
 	}
 
+	/// <summary>Mapped to InitSorting</summary>
 	public static I ChainInitSorting<I>(this I item, long order) where I : DataFeedItem {
 		item.InitSorting(order);
 		return item;
 	}
 
+	/// <summary>Mapped to InitSorting</summary>
 	public static I ChainInitSorting<I>(this I item, Func<long> orderGetter) where I : DataFeedItem {
 		item.InitSorting(orderGetter);
 		return item;
 	}
 
+	/// <summary>Mapped to SetOverrideSubpath</summary>
 	public static DataFeedCategory ChainSetOverrideSubpath(this DataFeedCategory item, params string[] subpath) {
 		item.SetOverrideSubpath(subpath);
 		return item;
 	}
 
+	/// <summary>Mapped to InitEntity</summary>
 	public static DataFeedEntity<E> ChainInitEntity<E>(this DataFeedEntity<E> item, E entity) {
 		item.InitEntity(entity);
 		return item;
 	}
 
+	/// <summary>Mapped to InitSetupValue</summary>
 	public static I ChainInitSetupValue<I, T>(this I item, Action<IField<T>> setup) where I : DataFeedValueElement<T> {
 		item.InitSetupValue(setup);
 		return item;
 	}
 
+	/// <summary>Mapped to InitFormatting</summary>
 	public static I ChainInitFormatting<I, T>(this I item, Action<IField<string>> setupFormatting) where I : DataFeedValueElement<T> {
 		item.InitFormatting(setupFormatting);
 		return item;
 	}
 
+	/// <summary>Mapped to InitFormatting</summary>
 	public static I ChainInitFormatting<I, T>(this I item, string formatting) where I : DataFeedValueElement<T> {
 		item.InitFormatting(formatting);
 		return item;
 	}
 
+	/// <summary>Mapped to InitSetup</summary>
 	public static DataFeedOrderedItem<T> ChainInitSetup<T>(this DataFeedOrderedItem<T> item, Action<IField<T>> orderValue, Action<IField<bool>> setupIsFirst, Action<IField<bool>> setupIsLast, Action<SyncDelegate<Action>> setupMoveUp, Action<SyncDelegate<Action>> setupMoveDown, Action<SyncDelegate<Action>> setupMakeFirst, Action<SyncDelegate<Action>> setupMakeLast, LocaleString moveUpLabel = default, LocaleString moveDownLabel = default, LocaleString makeFirstLabel = default, LocaleString makeLastLabel = default) where T : IComparable<T> {
 		item.InitSetup(orderValue, setupIsFirst, setupIsLast, setupMoveUp, setupMoveDown, setupMakeFirst, setupMakeLast, moveUpLabel, moveDownLabel, makeFirstLabel, makeLastLabel);
 		return item;
 	}
 
+	/// <summary>Mapped to InitSetup</summary>
 	public static I ChainInitSetup<I, T>(this I item, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max) where I : DataFeedClampedValueField<T> {
 		item.InitSetup(value, min, max);
 		return item;
 	}
+	/// <summary>Mapped to InitSetup</summary>
 	public static I ChainInitSetup<I, T>(this I item, Action<IField<T>> value, T min, T max) where I : DataFeedClampedValueField<T> {
 		item.InitSetup(value, min, max);
 		return item;
 	}
 
+	/// <summary>Mapped to InitUnitConfiguration</summary>
 	public static DataFeedQuantityField<Q, T> ChainInitUnitConfiguration<Q, T>(this DataFeedQuantityField<Q, T> item, UnitConfiguration defaultConfig, UnitConfiguration imperialConfig = null) where Q : unmanaged, IQuantity<Q> {
 		item.InitUnitConfiguration(defaultConfig, imperialConfig);
 		return item;
 	}
 
+	/// <summary>Mapped to InitSlider</summary>
 	public static DataFeedSlider<T> ChainInitSlider<T>(this DataFeedSlider<T> item, Action<IField<T>> setupReferenceValue) {
 		item.InitSlider(setupReferenceValue);
 		return item;
 	}
 
+	/// <summary>Mapped to InitAction</summary>
 	public static DataFeedAction ChainInitAction(this DataFeedAction item, Action<SyncDelegate<Action>> setupAction) {
 		item.InitAction(setupAction);
 		return item;
 	}
 
+	/// <summary>Mapped to InitHighlight</summary>
 	public static DataFeedAction ChainInitHighlight(this DataFeedAction item, Action<IField<bool>> setupHighlight) {
 		item.InitHighlight(setupHighlight);
 		return item;
 	}
 
+	/// <summary>Mapped to InitAction</summary>
 	public static DataFeedValueAction<T> ChainInitAction<T>(this DataFeedValueAction<T> item, Action<SyncDelegate<Action<T>>> setupAction, Action<IField<T>> setupValue) {
 		item.InitAction(setupAction, setupValue);
 		return item;
 	}
 
+	/// <summary>Mapped to InitAction</summary>
 	public static DataFeedValueAction<T> ChainInitAction<T>(this DataFeedValueAction<T> item, Action<SyncDelegate<Action<T>>> setupAction, T value) {
 		item.InitAction(setupAction, value);
 		return item;
 	}
 
+	/// <summary>Mapped to InitHighlight</summary>
 	public static DataFeedValueAction<T> ChainInitHighlight<T>(this DataFeedValueAction<T> item, Action<IField<bool>> setupHighlight) {
 		item.InitHighlight(setupHighlight);
 		return item;
 	}
 
+	/// <summary>Mapped to InitSetupValue</summary>
 	public static DataFeedIndicator<T> ChainInitSetupValue<T>(this DataFeedIndicator<T> item, Action<IField<T>> setup, string format = null) {
 		item.InitSetupValue(setup, format);
 		return item;
 	}
+
+	private static MethodInfo SubItemsSetter = AccessTools.PropertySetter(typeof(DataFeedItem), nameof(DataFeedItem.SubItems));
+
+	public static I Subitem<I>(this I item, params DataFeedItem[] subitem) where I : DataFeedItem {
+		if (item.SubItems is null)
+			SubItemsSetter.Invoke(item, [subitem]);
+		else
+			SubItemsSetter.Invoke(item, [item.SubItems.Concat(subitem).ToArray()]);
+		return item;
+	}
+
+	public static I ClearSubitems<I>(this I item, params DataFeedItem[] subitem) where I : DataFeedItem {
+		if (item.SubItems is not null && item.SubItems.Any())
+			SubItemsSetter.Invoke(item, [null]);
+		return item;
+	}
+#pragma warning restore CS8625, CA1715
 }

--- a/ResoniteModLoader/Utility/FeedBuilder.cs
+++ b/ResoniteModLoader/Utility/FeedBuilder.cs
@@ -4,18 +4,15 @@ using FrooxEngine;
 
 namespace ResoniteModLoader;
 
-public sealed class FeedBuilder {
-	public static T Item<T>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where T : DataFeedItem {
-		T item = Activator.CreateInstance<T>();
-		item.InitBase(itemKey, path, groupingParameters, label, icon, setupVisible, setupEnabled, subitems, customEntity);
-		return item;
-	}
+public static class FeedBuilder {
+	public static T Item<T>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where T : DataFeedItem
+		=> Activator.CreateInstance<T>().ChainInitBase(itemKey, path, groupingParameters, label, icon, setupVisible, setupEnabled, subitems, customEntity);
 
-	// CONFLICT AA
+	// CONFLICT AB
 	public static DataFeedCategory Category(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
 		=> Item<DataFeedCategory>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
 
-	// CONFLICT AB
+	// CONFLICT BA
 	public static DataFeedCategory Category(string itemKey, LocaleString label, string[] subpath, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
 		=> Category(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainSetOverrideSubpath(subpath);
 
@@ -68,10 +65,10 @@ public sealed class FeedBuilder {
 		=> Item<DataFeedLabel>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
 
 	public static DataFeedLabel Label(string itemKey, LocaleString label, colorX color, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
-		=> Label(itemKey, $"<c={color.ToHexString(true)}>{label}</c>", path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+		=> Label(itemKey, $"<color={color.ToHexString(true)}>{label}</color>", path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
 
 	public static DataFeedLabel Label(string itemKey, LocaleString label, color color, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
-		=> Label(itemKey, $"<c={color.ToHexString(true)}>{label}</c>", path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+		=> Label(itemKey, $"<color={color.ToHexString(true)}>{label}</color>", path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
 
 	public static DataFeedIndicator<T> Indicator<T>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
 		=> Item<DataFeedIndicator<T>>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
@@ -84,40 +81,345 @@ public sealed class FeedBuilder {
 	public static DataFeedIndicator<string> StringIndicator(string itemKey, LocaleString label, object value, string format = null, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
 		=> Indicator<string>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue((field) => field.Value = value.ToString(), format);
 
+	public static DataFeedToggle Toggle(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedToggle>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedToggle Toggle(string itemKey, LocaleString label, Action<IField<bool>> setup, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Toggle(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup);
+
+	public static DataFeedOrderedItem<T> OrderedItem<T>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where T : IComparable<T>
+		=> Item<DataFeedOrderedItem<T>>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedOrderedItem<T> OrderedItem<T>(string itemKey, LocaleString label, Func<long> orderGetter, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where T : IComparable<T>
+		=> OrderedItem<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSorting(orderGetter);
+
+	public static DataFeedOrderedItem<T> OrderedItem<T>(string itemKey, LocaleString label, long order, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where T : IComparable<T>
+		=> OrderedItem<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSorting(order);
+
+	public static DataFeedValueField<T> ValueField<T>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedValueField<T>>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedValueField<T> ValueField<T>(string itemKey, LocaleString label, Action<IField<T>> setup, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueField<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup);
+
+	public static DataFeedValueField<T> ValueField<T>(string itemKey, LocaleString label, Action<IField<T>> setup, Action<IField<string>> setupFormatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueField<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup).ChainInitFormatting<DataFeedValueField<T>, T>(setupFormatting);
+
+	public static DataFeedValueField<T> ValueField<T>(string itemKey, LocaleString label, Action<IField<T>> setup, string formatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueField<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup).ChainInitFormatting<DataFeedValueField<T>, T>(formatting);
+
+	public static DataFeedEnum<E> Enum<E>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where E : Enum
+		=> Item<DataFeedEnum<E>>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedEnum<E> Enum<E>(string itemKey, LocaleString label, Action<IField<E>> setup, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where E : Enum
+		=> Enum<E>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup);
+
+	public static DataFeedEnum<E> Enum<E>(string itemKey, LocaleString label, Action<IField<E>> setup, Action<IField<string>> setupFormatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where E : Enum
+		=> Enum<E>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup).ChainInitFormatting<DataFeedEnum<E>, E>(setupFormatting);
+
+	public static DataFeedEnum<E> Enum<E>(string itemKey, LocaleString label, Action<IField<E>> setup, string formatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where E : Enum
+		=> Enum<E>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup).ChainInitFormatting<DataFeedEnum<E>, E>(formatting);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedClampedValueField<T>>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ClampedValueField<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, Action<IField<string>> setupFormatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ClampedValueField<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedClampedValueField<T>, T>(setupFormatting);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, string formatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ClampedValueField<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedClampedValueField<T>, T>(formatting);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, Action<IField<T>> value, T min, T max, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ClampedValueField<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, Action<IField<T>> value, T min, T max, Action<IField<string>> setupFormatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ClampedValueField<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedClampedValueField<T>, T>(setupFormatting);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, Action<IField<T>> value, T min, T max, string formatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ClampedValueField<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedClampedValueField<T>, T>(formatting);
+
+	public static DataFeedQuantityField<Q, T> QuantityField<Q, T>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where Q : unmanaged, IQuantity<Q>
+		=> Item<DataFeedQuantityField<Q, T>>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedQuantityField<Q, T> QuantityField<Q, T>(string itemKey, LocaleString label, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where Q : unmanaged, IQuantity<Q>
+		=> QuantityField<Q, T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max);
+
+	public static DataFeedQuantityField<Q, T> QuantityField<Q, T>(string itemKey, LocaleString label, Action<IField<T>> value, T min, T max, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where Q : unmanaged, IQuantity<Q>
+		=> QuantityField<Q, T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max);
+
+	public static DataFeedQuantityField<Q, T> QuantityField<Q, T>(string itemKey, LocaleString label, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, UnitConfiguration defaultConfig, UnitConfiguration imperialConfig = null, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where Q : unmanaged, IQuantity<Q>
+		=> QuantityField<Q, T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitUnitConfiguration(defaultConfig, imperialConfig);
+
+	public static DataFeedQuantityField<Q, T> QuantityField<Q, T>(string itemKey, LocaleString label, Action<IField<T>> value, T min, T max, UnitConfiguration defaultConfig, UnitConfiguration imperialConfig = null, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where Q : unmanaged, IQuantity<Q>
+		=> QuantityField<Q, T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitUnitConfiguration(defaultConfig, imperialConfig);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedSlider<T>>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, Action<IField<string>> setupFormatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedSlider<T>, T>(setupFormatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, string formatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedSlider<T>, T>(formatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, Action<IField<T>> value, T min, T max, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, Action<IField<T>> value, T min, T max, Action<IField<string>> setupFormatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedSlider<T>, T>(setupFormatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, Action<IField<T>> value, T min, T max, string formatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedSlider<T>, T>(formatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, Action<IField<string>> setupFormatting, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue).ChainInitFormatting<DataFeedSlider<T>, T>(setupFormatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, string formatting, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue).ChainInitFormatting<DataFeedSlider<T>, T>(formatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, Action<IField<T>> value, T min, T max, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, Action<IField<T>> value, T min, T max, Action<IField<string>> setupFormatting, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue).ChainInitFormatting<DataFeedSlider<T>, T>(setupFormatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, Action<IField<T>> value, T min, T max, string formatting, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue).ChainInitFormatting<DataFeedSlider<T>, T>(formatting);
+
+	// With description
+
+	public static T Item<T>(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where T : DataFeedItem
+		=> Activator.CreateInstance<T>().ChainInitBase(itemKey, path, groupingParameters, label, description, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	// CONFLICT AB
+	public static DataFeedCategory Category(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedCategory>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	// CONFLICT BA
+	public static DataFeedCategory Category(string itemKey, LocaleString label, LocaleString description, string[] subpath, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Category(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainSetOverrideSubpath(subpath);
+
+	public static DataFeedGroup Group(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedGroup>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedGroup Group(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<DataFeedItem> subitems, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, object customEntity = null)
+		=> Group(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedGrid Grid(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedGrid>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedGrid Grid(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<DataFeedItem> subitems, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, object customEntity = null)
+		=> Grid(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedEntity<E> Entity<E>(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedEntity<E>>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedEntity<E> Entity<E>(string itemKey, LocaleString label, LocaleString description, E entity, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Entity<E>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitEntity(entity);
+
+	public static DataFeedAction Action(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedAction>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedAction Action(string itemKey, LocaleString label, LocaleString description, Action<SyncDelegate<Action>> setupAction, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Action(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitAction(setupAction);
+
+	public static DataFeedAction Action(string itemKey, LocaleString label, LocaleString description, Action<SyncDelegate<Action>> setupAction, Action<IField<bool>> setupHighlight, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Action(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitAction(setupAction).ChainInitHighlight(setupHighlight);
+
+	public static DataFeedValueAction<T> ValueAction<T>(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedValueAction<T>>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedValueAction<T> ValueAction<T>(string itemKey, LocaleString label, LocaleString description, Action<SyncDelegate<Action<T>>> setupAction, Action<IField<T>> setupValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueAction<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitAction(setupAction, setupValue);
+
+	public static DataFeedValueAction<T> ValueAction<T>(string itemKey, LocaleString label, LocaleString description, Action<SyncDelegate<Action<T>>> setupAction, T value, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueAction<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitAction(setupAction, value);
+
+	public static DataFeedValueAction<T> ValueAction<T>(string itemKey, LocaleString label, LocaleString description, Action<SyncDelegate<Action<T>>> setupAction, Action<IField<T>> setupValue, Action<IField<bool>> setupHighlight, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueAction<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitAction(setupAction, setupValue).ChainInitHighlight(setupHighlight);
+
+	public static DataFeedValueAction<T> ValueAction<T>(string itemKey, LocaleString label, LocaleString description, Action<SyncDelegate<Action<T>>> setupAction, T value, Action<IField<bool>> setupHighlight, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueAction<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitAction(setupAction, value).ChainInitHighlight(setupHighlight);
+
+	public static DataFeedSelection Selection(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedSelection>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedLabel Label(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedLabel>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedLabel Label(string itemKey, LocaleString label, LocaleString description, colorX color, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Label(itemKey, $"<color={color.ToHexString(true)}>{label}</color>", path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedLabel Label(string itemKey, LocaleString label, LocaleString description, color color, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Label(itemKey, $"<color={color.ToHexString(true)}>{label}</color>", path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedIndicator<T> Indicator<T>(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedIndicator<T>>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedIndicator<T> Indicator<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> setup, string format = null, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Indicator<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup, format);
+
+	public static DataFeedIndicator<T> Indicator<T>(string itemKey, LocaleString label, LocaleString description, T value, string format = null, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Indicator<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue((field) => field.Value = value, format);
+	public static DataFeedIndicator<string> StringIndicator(string itemKey, LocaleString label, LocaleString description, object value, string format = null, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Indicator<string>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue((field) => field.Value = value.ToString(), format);
+
+	public static DataFeedToggle Toggle(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedToggle>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedToggle Toggle(string itemKey, LocaleString label, LocaleString description, Action<IField<bool>> setup, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Toggle(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup);
+
+	public static DataFeedOrderedItem<T> OrderedItem<T>(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where T : IComparable<T>
+		=> Item<DataFeedOrderedItem<T>>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedOrderedItem<T> OrderedItem<T>(string itemKey, LocaleString label, LocaleString description, Func<long> orderGetter, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where T : IComparable<T>
+		=> OrderedItem<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSorting(orderGetter);
+
+	public static DataFeedOrderedItem<T> OrderedItem<T>(string itemKey, LocaleString label, LocaleString description, long order, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where T : IComparable<T>
+		=> OrderedItem<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSorting(order);
+
+	public static DataFeedValueField<T> ValueField<T>(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedValueField<T>>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedValueField<T> ValueField<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> setup, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueField<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup);
+
+	public static DataFeedValueField<T> ValueField<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> setup, Action<IField<string>> setupFormatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueField<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup).ChainInitFormatting<DataFeedValueField<T>, T>(setupFormatting);
+
+	public static DataFeedValueField<T> ValueField<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> setup, string formatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueField<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup).ChainInitFormatting<DataFeedValueField<T>, T>(formatting);
+
+	public static DataFeedEnum<E> Enum<E>(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where E : Enum
+		=> Item<DataFeedEnum<E>>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedEnum<E> Enum<E>(string itemKey, LocaleString label, LocaleString description, Action<IField<E>> setup, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where E : Enum
+		=> Enum<E>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup);
+
+	public static DataFeedEnum<E> Enum<E>(string itemKey, LocaleString label, LocaleString description, Action<IField<E>> setup, Action<IField<string>> setupFormatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where E : Enum
+		=> Enum<E>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup).ChainInitFormatting<DataFeedEnum<E>, E>(setupFormatting);
+
+	public static DataFeedEnum<E> Enum<E>(string itemKey, LocaleString label, LocaleString description, Action<IField<E>> setup, string formatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where E : Enum
+		=> Enum<E>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup).ChainInitFormatting<DataFeedEnum<E>, E>(formatting);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedClampedValueField<T>>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ClampedValueField<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, Action<IField<string>> setupFormatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ClampedValueField<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedClampedValueField<T>, T>(setupFormatting);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, string formatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ClampedValueField<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedClampedValueField<T>, T>(formatting);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, T min, T max, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ClampedValueField<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, T min, T max, Action<IField<string>> setupFormatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ClampedValueField<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedClampedValueField<T>, T>(setupFormatting);
+
+	public static DataFeedClampedValueField<T> ClampedValueField<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, T min, T max, string formatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ClampedValueField<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedClampedValueField<T>, T>(formatting);
+
+	public static DataFeedQuantityField<Q, T> QuantityField<Q, T>(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where Q : unmanaged, IQuantity<Q>
+		=> Item<DataFeedQuantityField<Q, T>>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedQuantityField<Q, T> QuantityField<Q, T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where Q : unmanaged, IQuantity<Q>
+		=> QuantityField<Q, T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max);
+
+	public static DataFeedQuantityField<Q, T> QuantityField<Q, T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, T min, T max, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where Q : unmanaged, IQuantity<Q>
+		=> QuantityField<Q, T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max);
+
+	public static DataFeedQuantityField<Q, T> QuantityField<Q, T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, UnitConfiguration defaultConfig, UnitConfiguration imperialConfig = null, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where Q : unmanaged, IQuantity<Q>
+		=> QuantityField<Q, T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitUnitConfiguration(defaultConfig, imperialConfig);
+
+	public static DataFeedQuantityField<Q, T> QuantityField<Q, T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, T min, T max, UnitConfiguration defaultConfig, UnitConfiguration imperialConfig = null, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where Q : unmanaged, IQuantity<Q>
+		=> QuantityField<Q, T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitUnitConfiguration(defaultConfig, imperialConfig);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedSlider<T>>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, Action<IField<string>> setupFormatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedSlider<T>, T>(setupFormatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, string formatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedSlider<T>, T>(formatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, T min, T max, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, T min, T max, Action<IField<string>> setupFormatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedSlider<T>, T>(setupFormatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, T min, T max, string formatting, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitFormatting<DataFeedSlider<T>, T>(formatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, Action<IField<string>> setupFormatting, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue).ChainInitFormatting<DataFeedSlider<T>, T>(setupFormatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max, string formatting, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue).ChainInitFormatting<DataFeedSlider<T>, T>(formatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, T min, T max, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, T min, T max, Action<IField<string>> setupFormatting, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue).ChainInitFormatting<DataFeedSlider<T>, T>(setupFormatting);
+
+	public static DataFeedSlider<T> Slider<T>(string itemKey, LocaleString label, LocaleString description, Action<IField<T>> value, T min, T max, string formatting, Action<IField<T>> setupReferenceValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Slider<T>(itemKey, label, description, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetup(value, min, max).ChainInitSlider(setupReferenceValue).ChainInitFormatting<DataFeedSlider<T>, T>(formatting);
 }
 
 public static class DataFeedItemChaining {
-	public static DataFeedItem ChainInitBase(this DataFeedItem item, string itemKey, IReadOnlyList<string> path, IReadOnlyList<string> groupingParameters, LocaleString label, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) {
+	public static I ChainInitBase<I>(this I item, string itemKey, IReadOnlyList<string> path, IReadOnlyList<string> groupingParameters, LocaleString label, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where I : DataFeedItem {
 		item.InitBase(itemKey, path, groupingParameters, label, icon, setupVisible, setupEnabled, subitems, customEntity);
 		return item;
 	}
 
-	public static DataFeedItem ChainInitBase(this DataFeedItem item, string itemKey, IReadOnlyList<string> path, IReadOnlyList<string> groupingParameters, LocaleString label, LocaleString description, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) {
+	public static I ChainInitBase<I>(this I item, string itemKey, IReadOnlyList<string> path, IReadOnlyList<string> groupingParameters, LocaleString label, LocaleString description, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where I : DataFeedItem {
 		item.InitBase(itemKey, path, groupingParameters, label, description, icon, setupVisible, setupEnabled, subitems, customEntity);
 		return item;
 	}
 
-	public static DataFeedItem ChainInitVisible(this DataFeedItem item, Action<IField<bool>> setupVisible) {
+	public static I ChainInitVisible<I>(this I item, Action<IField<bool>> setupVisible) where I : DataFeedItem {
 		item.InitVisible(setupVisible);
 		return item;
 	}
 
-	public static DataFeedItem ChainInitEnabled(this DataFeedItem item, Action<IField<bool>> setupEnabled) {
+	public static I ChainInitEnabled<I>(this I item, Action<IField<bool>> setupEnabled) where I : DataFeedItem {
 		item.InitEnabled(setupEnabled);
 		return item;
 	}
 
-	public static DataFeedItem ChainInitDescription(this DataFeedItem item, LocaleString description) {
+	public static I ChainInitDescription<I>(this I item, LocaleString description) where I : DataFeedItem {
 		item.InitDescription(description);
 		return item;
 	}
 
-	public static DataFeedItem ChainInitSorting(this DataFeedItem item, long order) {
+	public static I ChainInitSorting<I>(this I item, long order) where I : DataFeedItem {
 		item.InitSorting(order);
 		return item;
 	}
 
-	public static DataFeedItem ChainInitSorting(this DataFeedItem item, Func<long> orderGetter) {
+	public static I ChainInitSorting<I>(this I item, Func<long> orderGetter) where I : DataFeedItem {
 		item.InitSorting(orderGetter);
 		return item;
 	}
@@ -132,17 +434,17 @@ public static class DataFeedItemChaining {
 		return item;
 	}
 
-	public static DataFeedValueElement<T> ChainInitSetupValue<T>(this DataFeedValueElement<T> item, Action<IField<T>> setup) {
+	public static I ChainInitSetupValue<I, T>(this I item, Action<IField<T>> setup) where I : DataFeedValueElement<T> {
 		item.InitSetupValue(setup);
 		return item;
 	}
 
-	public static DataFeedValueElement<T> ChainInitFormatting<T>(this DataFeedValueElement<T> item, Action<IField<string>> setupFormatting) {
+	public static I ChainInitFormatting<I, T>(this I item, Action<IField<string>> setupFormatting) where I : DataFeedValueElement<T> {
 		item.InitFormatting(setupFormatting);
 		return item;
 	}
 
-	public static DataFeedValueElement<T> ChainInitFormatting<T>(this DataFeedValueElement<T> item, string formatting) {
+	public static I ChainInitFormatting<I, T>(this I item, string formatting) where I : DataFeedValueElement<T> {
 		item.InitFormatting(formatting);
 		return item;
 	}
@@ -152,11 +454,11 @@ public static class DataFeedItemChaining {
 		return item;
 	}
 
-	public static DataFeedClampedValueField<T> ChainInitSetup<T>(this DataFeedClampedValueField<T> item, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max) {
+	public static I ChainInitSetup<I, T>(this I item, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max) where I : DataFeedClampedValueField<T> {
 		item.InitSetup(value, min, max);
 		return item;
 	}
-	public static DataFeedClampedValueField<T> ChainInitSetup<T>(this DataFeedClampedValueField<T> item, Action<IField<T>> value, T min, T max) {
+	public static I ChainInitSetup<I, T>(this I item, Action<IField<T>> value, T min, T max) where I : DataFeedClampedValueField<T> {
 		item.InitSetup(value, min, max);
 		return item;
 	}

--- a/ResoniteModLoader/Utility/FeedBuilder.cs
+++ b/ResoniteModLoader/Utility/FeedBuilder.cs
@@ -1,0 +1,203 @@
+using Elements.Core;
+using Elements.Quantity;
+using FrooxEngine;
+
+namespace ResoniteModLoader;
+
+public sealed class FeedBuilder {
+	public static T Item<T>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) where T : DataFeedItem {
+		T item = Activator.CreateInstance<T>();
+		item.InitBase(itemKey, path, groupingParameters, label, icon, setupVisible, setupEnabled, subitems, customEntity);
+		return item;
+	}
+
+	// CONFLICT AA
+	public static DataFeedCategory Category(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedCategory>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	// CONFLICT AB
+	public static DataFeedCategory Category(string itemKey, LocaleString label, string[] subpath, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Category(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainSetOverrideSubpath(subpath);
+
+	public static DataFeedGroup Group(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedGroup>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedGroup Group(string itemKey, LocaleString label, IReadOnlyList<DataFeedItem> subitems, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, object customEntity = null)
+		=> Group(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedGrid Grid(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedGrid>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedGrid Grid(string itemKey, LocaleString label, IReadOnlyList<DataFeedItem> subitems, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, object customEntity = null)
+		=> Grid(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedEntity<E> Entity<E>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedEntity<E>>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedEntity<E> Entity<E>(string itemKey, LocaleString label, E entity, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Entity<E>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitEntity(entity);
+
+	public static DataFeedAction Action(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedAction>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedAction Action(string itemKey, LocaleString label, Action<SyncDelegate<Action>> setupAction, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Action(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitAction(setupAction);
+
+	public static DataFeedAction Action(string itemKey, LocaleString label, Action<SyncDelegate<Action>> setupAction, Action<IField<bool>> setupHighlight, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Action(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitAction(setupAction).ChainInitHighlight(setupHighlight);
+
+	public static DataFeedValueAction<T> ValueAction<T>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedValueAction<T>>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedValueAction<T> ValueAction<T>(string itemKey, LocaleString label, Action<SyncDelegate<Action<T>>> setupAction, Action<IField<T>> setupValue, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueAction<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitAction(setupAction, setupValue);
+
+	public static DataFeedValueAction<T> ValueAction<T>(string itemKey, LocaleString label, Action<SyncDelegate<Action<T>>> setupAction, T value, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueAction<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitAction(setupAction, value);
+
+	public static DataFeedValueAction<T> ValueAction<T>(string itemKey, LocaleString label, Action<SyncDelegate<Action<T>>> setupAction, Action<IField<T>> setupValue, Action<IField<bool>> setupHighlight, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueAction<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitAction(setupAction, setupValue).ChainInitHighlight(setupHighlight);
+
+	public static DataFeedValueAction<T> ValueAction<T>(string itemKey, LocaleString label, Action<SyncDelegate<Action<T>>> setupAction, T value, Action<IField<bool>> setupHighlight, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> ValueAction<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitAction(setupAction, value).ChainInitHighlight(setupHighlight);
+
+	public static DataFeedSelection Selection(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedSelection>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedLabel Label(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedLabel>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedLabel Label(string itemKey, LocaleString label, colorX color, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Label(itemKey, $"<c={color.ToHexString(true)}>{label}</c>", path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedLabel Label(string itemKey, LocaleString label, color color, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Label(itemKey, $"<c={color.ToHexString(true)}>{label}</c>", path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedIndicator<T> Indicator<T>(string itemKey, LocaleString label, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Item<DataFeedIndicator<T>>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity);
+
+	public static DataFeedIndicator<T> Indicator<T>(string itemKey, LocaleString label, Action<IField<T>> setup, string format = null, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Indicator<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue(setup, format);
+
+	public static DataFeedIndicator<T> Indicator<T>(string itemKey, LocaleString label, T value, string format = null, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Indicator<T>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue((field) => field.Value = value, format);
+	public static DataFeedIndicator<string> StringIndicator(string itemKey, LocaleString label, object value, string format = null, IReadOnlyList<string> path = null, IReadOnlyList<string> groupingParameters = null, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null)
+		=> Indicator<string>(itemKey, label, path, groupingParameters, icon, setupVisible, setupEnabled, subitems, customEntity).ChainInitSetupValue((field) => field.Value = value.ToString(), format);
+
+}
+
+public static class DataFeedItemChaining {
+	public static DataFeedItem ChainInitBase(this DataFeedItem item, string itemKey, IReadOnlyList<string> path, IReadOnlyList<string> groupingParameters, LocaleString label, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) {
+		item.InitBase(itemKey, path, groupingParameters, label, icon, setupVisible, setupEnabled, subitems, customEntity);
+		return item;
+	}
+
+	public static DataFeedItem ChainInitBase(this DataFeedItem item, string itemKey, IReadOnlyList<string> path, IReadOnlyList<string> groupingParameters, LocaleString label, LocaleString description, Uri icon = null, Action<IField<bool>> setupVisible = null, Action<IField<bool>> setupEnabled = null, IReadOnlyList<DataFeedItem> subitems = null, object customEntity = null) {
+		item.InitBase(itemKey, path, groupingParameters, label, description, icon, setupVisible, setupEnabled, subitems, customEntity);
+		return item;
+	}
+
+	public static DataFeedItem ChainInitVisible(this DataFeedItem item, Action<IField<bool>> setupVisible) {
+		item.InitVisible(setupVisible);
+		return item;
+	}
+
+	public static DataFeedItem ChainInitEnabled(this DataFeedItem item, Action<IField<bool>> setupEnabled) {
+		item.InitEnabled(setupEnabled);
+		return item;
+	}
+
+	public static DataFeedItem ChainInitDescription(this DataFeedItem item, LocaleString description) {
+		item.InitDescription(description);
+		return item;
+	}
+
+	public static DataFeedItem ChainInitSorting(this DataFeedItem item, long order) {
+		item.InitSorting(order);
+		return item;
+	}
+
+	public static DataFeedItem ChainInitSorting(this DataFeedItem item, Func<long> orderGetter) {
+		item.InitSorting(orderGetter);
+		return item;
+	}
+
+	public static DataFeedCategory ChainSetOverrideSubpath(this DataFeedCategory item, params string[] subpath) {
+		item.SetOverrideSubpath(subpath);
+		return item;
+	}
+
+	public static DataFeedEntity<E> ChainInitEntity<E>(this DataFeedEntity<E> item, E entity) {
+		item.InitEntity(entity);
+		return item;
+	}
+
+	public static DataFeedValueElement<T> ChainInitSetupValue<T>(this DataFeedValueElement<T> item, Action<IField<T>> setup) {
+		item.InitSetupValue(setup);
+		return item;
+	}
+
+	public static DataFeedValueElement<T> ChainInitFormatting<T>(this DataFeedValueElement<T> item, Action<IField<string>> setupFormatting) {
+		item.InitFormatting(setupFormatting);
+		return item;
+	}
+
+	public static DataFeedValueElement<T> ChainInitFormatting<T>(this DataFeedValueElement<T> item, string formatting) {
+		item.InitFormatting(formatting);
+		return item;
+	}
+
+	public static DataFeedOrderedItem<T> ChainInitSetup<T>(this DataFeedOrderedItem<T> item, Action<IField<T>> orderValue, Action<IField<bool>> setupIsFirst, Action<IField<bool>> setupIsLast, Action<SyncDelegate<Action>> setupMoveUp, Action<SyncDelegate<Action>> setupMoveDown, Action<SyncDelegate<Action>> setupMakeFirst, Action<SyncDelegate<Action>> setupMakeLast, LocaleString moveUpLabel = default, LocaleString moveDownLabel = default, LocaleString makeFirstLabel = default, LocaleString makeLastLabel = default) where T : IComparable<T> {
+		item.InitSetup(orderValue, setupIsFirst, setupIsLast, setupMoveUp, setupMoveDown, setupMakeFirst, setupMakeLast, moveUpLabel, moveDownLabel, makeFirstLabel, makeLastLabel);
+		return item;
+	}
+
+	public static DataFeedClampedValueField<T> ChainInitSetup<T>(this DataFeedClampedValueField<T> item, Action<IField<T>> value, Action<IField<T>> min, Action<IField<T>> max) {
+		item.InitSetup(value, min, max);
+		return item;
+	}
+	public static DataFeedClampedValueField<T> ChainInitSetup<T>(this DataFeedClampedValueField<T> item, Action<IField<T>> value, T min, T max) {
+		item.InitSetup(value, min, max);
+		return item;
+	}
+
+	public static DataFeedQuantityField<Q, T> ChainInitUnitConfiguration<Q, T>(this DataFeedQuantityField<Q, T> item, UnitConfiguration defaultConfig, UnitConfiguration imperialConfig = null) where Q : unmanaged, IQuantity<Q> {
+		item.InitUnitConfiguration(defaultConfig, imperialConfig);
+		return item;
+	}
+
+	public static DataFeedSlider<T> ChainInitSlider<T>(this DataFeedSlider<T> item, Action<IField<T>> setupReferenceValue) {
+		item.InitSlider(setupReferenceValue);
+		return item;
+	}
+
+	public static DataFeedAction ChainInitAction(this DataFeedAction item, Action<SyncDelegate<Action>> setupAction) {
+		item.InitAction(setupAction);
+		return item;
+	}
+
+	public static DataFeedAction ChainInitHighlight(this DataFeedAction item, Action<IField<bool>> setupHighlight) {
+		item.InitHighlight(setupHighlight);
+		return item;
+	}
+
+	public static DataFeedValueAction<T> ChainInitAction<T>(this DataFeedValueAction<T> item, Action<SyncDelegate<Action<T>>> setupAction, Action<IField<T>> setupValue) {
+		item.InitAction(setupAction, setupValue);
+		return item;
+	}
+
+	public static DataFeedValueAction<T> ChainInitAction<T>(this DataFeedValueAction<T> item, Action<SyncDelegate<Action<T>>> setupAction, T value) {
+		item.InitAction(setupAction, value);
+		return item;
+	}
+
+	public static DataFeedValueAction<T> ChainInitHighlight<T>(this DataFeedValueAction<T> item, Action<IField<bool>> setupHighlight) {
+		item.InitHighlight(setupHighlight);
+		return item;
+	}
+
+	public static DataFeedIndicator<T> ChainInitSetupValue<T>(this DataFeedIndicator<T> item, Action<IField<T>> setup, string format = null) {
+		item.InitSetupValue(setup, format);
+		return item;
+	}
+}


### PR DESCRIPTION
Addressing #11, still heavily work-in-progress.

This PR introduces two new components: ModConfigurationDataFeed and ModConfigurationValueSync<T>. Together along with the new FeedBuilder and ModConfigurationFeedBuilder utility classes, this lays the groundwork for users being able to configure mods in-game without the needing to rely on another mod to do so. Additionally, it will allow mods to optionally build their own configuration data feeds, while also providing an automatic configuration feed builder for mods that do not implement their own. In addition to managing mod configurations, the new DataFeed will also let users easily view and copy logs & exceptions in-game.

Things that still need to happen before this is ready to get merged:
- [ ] Document all public methods & members (XML)
- [ ] Document new classes (Wiki)
  - [ ] FeedBuilder
  - [ ] Logger
  - [ ] ModConfigurationDataFeed
  - [ ] ModConfigurationFeedBuilder
  - [ ] ModConfigurationValueSync
  - [ ] ResoniteMod.BuildConfigurationFeed
  - [ ] AutoRegisterConfigKeyAttribute.Group
- [ ] Finalize FeedBuilder extension methods and names
- [ ] Add support for GroupingAttribute and possibly CategoryAttribute to ModConfigurationFeedBuilder
- [ ] Add support for ordered/enumerable types to ModConfigurationFeedBuilder
- [ ] Create DataFeed item templates for each engine primitive type
- [ ] Add support for ModConfigurationDataFeed being usable in a RootCategoryView
- [ ] Complete ModConfigurationValueSync component

There's probably a few more TODO items I couldn't think about listing, but that's the bulk of my assignment. I've intentionally disabled maintainer edits so long as this PR is a draft. Comments and feedback welcome!