### PR TITLE
Minor fixes to the splittening version

### DIFF
--- a/ResoniteModLoader/LoadProgressIndicator.cs
+++ b/ResoniteModLoader/LoadProgressIndicator.cs
@@ -4,33 +4,11 @@ namespace ResoniteModLoader;
 
 // Custom LoadProgressIndicator logic failing shouldn't stop the rest of the modloader.
 internal static class LoadProgressIndicator {
-	private static bool failed;
-
-	private static FieldInfo? _showSubphase;
-	private static FieldInfo? ShowSubphase {
-		get {
-			if (_showSubphase is null) {
-				try {
-					_showSubphase = typeof(EngineLoadProgress).GetField("_showSubphase", BindingFlags.NonPublic | BindingFlags.Instance);
-				} catch (Exception ex) {
-					if (!failed) {
-						Logger.WarnInternal("_showSubphase not found: " + ex.ToString());
-					}
-					failed = true;
-				}
-			}
-			return _showSubphase;
-		}
-	}
-
 	// Returned true means success, false means something went wrong.
 	internal static bool SetCustom(string text) {
 		if (ModLoaderConfiguration.Get().HideVisuals) { return true; }
-		if (!ModLoader.IsHeadless) {
-			ShowSubphase?.SetValue(Engine.Current.InitProgress, text);
-			return true;
-		}
-		return false;
+		Engine.Current.InitProgress.SetSubphase(text, true);
+		return true;
 	}
 }
 

--- a/ResoniteModLoader/ModLoader.cs
+++ b/ResoniteModLoader/ModLoader.cs
@@ -29,7 +29,15 @@ public sealed class ModLoader {
 				} catch (ReflectionTypeLoadException e) {
 					types = e.Types;
 				}
-				return types.Any(t => t != null && t.Namespace == "FrooxEngine.Headless");
+				return types.Any(t => {
+					try {
+						return t != null && t.Namespace == "FrooxEngine.Headless";
+					}
+					catch {
+						return false;
+					}
+				}
+				);
 			});
 		}
 	}

--- a/ResoniteModLoader/ResoniteModLoader.csproj
+++ b/ResoniteModLoader/ResoniteModLoader.csproj
@@ -50,6 +50,16 @@
 			<HintPath>$(ResonitePath)Newtonsoft.Json.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
+		<!-- Provides EngineLoadProgress-->
+		<Reference Include="Assembly-CSharp">
+			<HintPath>$(ResonitePath)Resonite_Data\Managed\Assembly-CSharp.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
+		<!--Monobehaviour in loading indicator-->
+		<Reference Include="UnityEngine.CoreModule">
+			<HintPath>$(ResonitePath)Resonite_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
+			<Private>False</Private>
+		</Reference>
 	</ItemGroup>
 
 	<ItemGroup>

--- a/ResoniteModLoader/ResoniteModLoader.csproj
+++ b/ResoniteModLoader/ResoniteModLoader.csproj
@@ -50,16 +50,6 @@
 			<HintPath>$(ResonitePath)Newtonsoft.Json.dll</HintPath>
 			<Private>False</Private>
 		</Reference>
-		<!-- Provides EngineLoadProgress-->
-		<Reference Include="Assembly-CSharp">
-			<HintPath>$(ResonitePath)Resonite_Data\Managed\Assembly-CSharp.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
-		<!--Monobehaviour in loading indicator-->
-		<Reference Include="UnityEngine.CoreModule">
-			<HintPath>$(ResonitePath)Resonite_Data\Managed\UnityEngine.CoreModule.dll</HintPath>
-			<Private>False</Private>
-		</Reference>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
This branch works well for the most part, but I had some minor trouble running it.

First off, there were error logs about not being able to hook some function for ResoniteModLoader.ModLoaderSettings, despite this class or namespace not appearing in this repo (is this compiled against another secondary repo?).
```
Exception:
System.Exception: Exception during initializing Worker of type ResoniteModLoader.ModLoaderSettings
 ---> System.MethodAccessException: Attempt by method 'ResoniteModLoader.ModLoaderSettings.InitializeSyncMembers()' to access method 'FrooxEngine.SyncElement.MarkNonPersistent()' failed.
   at ResoniteModLoader.ModLoaderSettings.InitializeSyncMembers()
   at FrooxEngine.Worker.InitializeWorker(IWorldElement parent) in D:\Workspace\Everion\FrooxEngine\FrooxEngine\Data Model\Base Classes\Worker.cs:line 237
   --- End of inner exception stack trace ---
[etc. etc.]
```
So I had to try building the mod loader from source myself from the branch.

When building it, I had an issue because of a missing binding for a Unity DLL used for the loading indicator. I managed to find a cleaner way to use the new interfaces in the FrooxEngine to set the loading messages, which should work both on headless and graphical clients.

After that, I also encountered an error where one of the managed DLLs (Steamworks.NET.dll) caused a crash due to an illegible namespace. I had to work around that by adding a try/catch around the assembly search to check if we are running on headless.

```
11:55:23 PM.799	[ERROR][ResoniteModLoader] Exception during initialization!
System.TypeLoadException: Could not load type 'OptionValue' from assembly 'Steamworks.NET, Version=2024.8.0.0, Culture=neutral, PublicKeyToken=null' because it contains an object field at offset 0 that is incorrectly aligned or overlapped by a non-object field.
   at System.RuntimeTypeHandle.GetDeclaringType(RuntimeType type)
   at System.RuntimeType.RuntimeTypeCache.GetEnclosingType()
   at System.RuntimeType.RuntimeTypeCache.GetNameSpace()
   at System.RuntimeType.get_Namespace()
   at ResoniteModLoader.ModLoader.<>c.<get_IsHeadless>b__7_1(Type t)
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at ResoniteModLoader.ModLoader.<>c.<get_IsHeadless>b__7_0(Assembly a)
   at System.Linq.Enumerable.Any[TSource](IEnumerable`1 source, Func`2 predicate)
   at ResoniteModLoader.ModLoader.get_IsHeadless()
   at ResoniteModLoader.LoadProgressIndicator.SetCustom(String text)
   at ResoniteModLoader.ModLoaderInit.Initialize()
```

These are the fixes I made to solve these issues. Now, everything loads without any noticeable problem or error log.