### PR TITLE
Fix: Use Elements.Core in ModLoaderSettings.cs

### DIFF
--- a/ResoniteModLoader/Settings/ModLoaderSettings.cs
+++ b/ResoniteModLoader/Settings/ModLoaderSettings.cs
@@ -1,5 +1,5 @@
 using System.Globalization;
-
+using Elements.Core;
 using FrooxEngine;
 
 namespace ResoniteModLoader;


### PR DESCRIPTION
The current main branch of RML can't be built because the type float3 can't be found since the namespace Elements.Core is not used.