### PR TITLE
Fixup: Use RawOutput instead of Sync for readonly indicators in settings

### DIFF
--- a/ResoniteModLoader/Settings/ModLoaderSettings.cs
+++ b/ResoniteModLoader/Settings/ModLoaderSettings.cs
@@ -11,10 +11,10 @@ public sealed class ModLoaderSettings : SettingComponent<ModLoaderSettings> {
 	public override bool UserspaceOnly => true;
 
 	[SettingIndicatorProperty]
-	public readonly Sync<string> LoadedMods;
+	public readonly RawOutput<string> LoadedMods;
 
 	[SettingIndicatorProperty]
-	public readonly Sync<string> ModLoaderVersion;
+	public readonly RawOutput<string> ModLoaderVersion;
 
 	[SettingProperty]
 	public readonly Sync<bool> DebugMode;
@@ -24,7 +24,7 @@ public sealed class ModLoaderSettings : SettingComponent<ModLoaderSettings> {
 
 	//TODO make clickable link in UI
 	[SettingIndicatorProperty]
-	public readonly Sync<string> ProjectLink;
+	public readonly RawOutput<string> ProjectLink;
 
 	[SettingProperty("Open Github Repo", "")]
 	[SyncMethod(typeof(Action), [])]


### PR DESCRIPTION
This doesn't change anything functionally, just prevents those values from being saved since they are only ever written to, so they're using the intended data model type for this usage.