### PR TITLE
Fixup: No list copies for ModLoader.Mods

### DIFF
--- a/ResoniteModLoader/ModLoader.cs
+++ b/ResoniteModLoader/ModLoader.cs
@@ -48,10 +48,8 @@ public sealed class ModLoader {
 	/// <summary>
 	/// Allows reading metadata for all loaded mods
 	/// </summary>
-	/// <returns>A new list containing each loaded mod</returns>
-	public static IEnumerable<ResoniteModBase> Mods() {
-		return LoadedMods.ToList();
-	}
+	/// <returns>A readonly list containing each loaded mod</returns>
+	public static IEnumerable<ResoniteModBase> Mods() => LoadedMods.AsReadOnly();
 
 	internal static void LoadMods() {
 		ModLoaderConfiguration config = ModLoaderConfiguration.Get();


### PR DESCRIPTION
In favor of #17, this solution makes `ModLoader.Mods()` return a readonly view of the list instead of returning the list itself or making a copy.

Technically, this is a different API behavior than copying the list, however RML does not expose any way to modify the list by loading or unloading mods, therefore there is no perceivable difference for a user of the public API.

#17 just returns the list (casting it to `IEnumerable<>`). This relies on the type system to guard against modification, but does not prevent casting it back to a modifiable type and is not good practice since we have `List.AsReadOnly` for this purpose.