### PR TITLE
CI: Produce valid NuGet package

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,7 @@ on:
   workflow_call: {}
 
 env:
+  CI_BUILD: true
   ARTIFACT_DIR: ResoniteModLoader/bin/Release/net10.0/
   NUGET_DIR: ResoniteModLoader/bin/Release/
 
@@ -62,7 +63,9 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: NuGet Packages
-          path: "${{ env.NUGET_DIR }}*.nupkg"
+          path: |
+            ${{ env.NUGET_DIR }}*.nupkg
+            ${{ env.NUGET_DIR }}*.snupkg
           if-no-files-found: error
 
       - name: Attest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -75,4 +75,6 @@ jobs:
           path: ${{ github.workspace }}/nupkgs
 
       - name: Publish package to registry
-        run: dotnet nuget push "${{ github.workspace }}/nupkgs/*.nupkg" --api-key "${{ secrets.NUGET_APIKEY }}" --source "${{ env.NUGET_REGISTRY_URL }}"
+        run: |
+          dotnet nuget push "${{ github.workspace }}/nupkgs/*.nupkg" --api-key "${{ secrets.NUGET_APIKEY }}" --source "${{ env.NUGET_REGISTRY_URL }}"
+          dotnet nuget push "${{ github.workspace }}/nupkgs/*.snupkg" --api-key "${{ secrets.NUGET_APIKEY }}" --source "${{ env.NUGET_REGISTRY_URL }}"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -7,6 +7,14 @@
 		<ImplicitUsings>enable</ImplicitUsings>
 		<EnableNETAnalyzers>True</EnableNETAnalyzers>
 		<AnalysisLevel>10.0-Recommended</AnalysisLevel>
+
+		<IncludeSymbols>true</IncludeSymbols>
+		<SymbolPackageFormat>snupkg</SymbolPackageFormat>
+		<DebugType>portable</DebugType>
+
+		<PackageProjectUrl>https://github.com/resonite-modding-group/ResoniteModLoader</PackageProjectUrl>
+		<PublishRepositoryUrl>true</PublishRepositoryUrl>
+		<PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
 	</PropertyGroup>
 
 	<PropertyGroup Condition="'$(ResonitePath)'==''">
@@ -14,6 +22,11 @@
 		<ResonitePath>$(MSBuildThisFileDirectory)Resonite/</ResonitePath>
 		<ResonitePath Condition="Exists('C:\Program Files (x86)\Steam\steamapps\common\Resonite\')">C:\Program Files (x86)\Steam\steamapps\common\Resonite\</ResonitePath>
 		<ResonitePath Condition="Exists('$(HOME)/.steam/steam/steamapps/common/Resonite/')">$(HOME)/.steam/steam/steamapps/common/Resonite/</ResonitePath>
+	</PropertyGroup>
+
+	<PropertyGroup Condition="'$(CI_BUILD)'=='true'">
+		<ContinuousIntegrationBuild>true</ContinuousIntegrationBuild>
+		<CopyToLibraries>false</CopyToLibraries>
 	</PropertyGroup>
 
 </Project>

--- a/ResoniteModLoader/ResoniteModLoader.csproj
+++ b/ResoniteModLoader/ResoniteModLoader.csproj
@@ -16,10 +16,7 @@
 		<Authors>resonite-modding-group, DeltaWolf</Authors>
 		<Description>A modloader for Resonite</Description>
 		<Copyright>Copyright © 2026</Copyright>
-		<PackageTags>mod mods modding modloader harmony resonite game resonitemodloader frooxengine</PackageTags>
-		<PackageProjectUrl>https://github.com/resonite-modding-group/ResoniteModLoader</PackageProjectUrl>
-		<RepositoryUrl>$(PackageProjectUrl).git</RepositoryUrl>
-		<PackageLicenseExpression>LGPL-3.0-or-later</PackageLicenseExpression>
+		<PackageTags>mod;mods;modding;modloader;harmony;resonite;game;resonitemodloader;frooxengine</PackageTags>
 		<PackageIcon>icon.png</PackageIcon>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 	</PropertyGroup>


### PR DESCRIPTION
This makes CI produces a valid NuGet package.
Example: https://github.com/ColinTimBarndt/ResoniteModLoader/actions/runs/21474304913/job/61854489504